### PR TITLE
Add few tests for html only syntax

### DIFF
--- a/test/formatting-html-only/index.ts
+++ b/test/formatting-html-only/index.ts
@@ -1,0 +1,29 @@
+import test from 'ava';
+import { readdirSync, readFileSync } from 'fs';
+import { format } from 'prettier';
+
+const files = readdirSync('test/formatting-html-only/samples').filter(name =>
+    name.endsWith('.html'),
+);
+
+for (const file of files) {
+    const input = readFileSync(`test/formatting-html-only/samples/${file}`, 'utf-8').replace(
+        /\r?\n/g,
+        '\n',
+    );
+
+    test(`formatting html: ${file.slice(0, file.length - '.html'.length)}`, t => {
+        const expectedOutput = format(input, {
+            parser: 'html' as any,
+            tabWidth: 4,
+        } as any);
+
+        const actualOutput = format(input, {
+            parser: 'svelte' as any,
+            plugins: [require.resolve('../../src')],
+            tabWidth: 4,
+        } as any);
+
+        t.is(expectedOutput, actualOutput);
+    });
+}

--- a/test/formatting-html-only/samples/closing-at-start.html
+++ b/test/formatting-html-only/samples/closing-at-start.html
@@ -1,0 +1,15 @@
+<div>
+    aaaaaaaaaa
+    <a
+      href="longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"
+      >bbbbbbbbbb</a
+    >
+    cccccccccc
+</div>
+<div>
+    aaaaaaaaaa
+    <a
+      href="longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"
+      >bbbbbbbbbb</a
+    >cccccccccc
+</div>

--- a/test/formatting-html-only/samples/comment.html
+++ b/test/formatting-html-only/samples/comment.html
@@ -1,0 +1,1 @@
+<!--hello world-->

--- a/test/formatting-html-only/samples/custom-element.html
+++ b/test/formatting-html-only/samples/custom-element.html
@@ -1,0 +1,2 @@
+<app-foo></app-foo>
+<app-bar></app-bar>

--- a/test/formatting-html-only/samples/form.html
+++ b/test/formatting-html-only/samples/form.html
@@ -1,0 +1,68 @@
+<form>
+  <div class="form-group">
+    <label for="exampleInputEmail1">Email address</label>
+    <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter email">
+    <small id="emailHelp" class="form-text text-muted">We'll never share your email with anyone else.</small>
+  </div>
+  <div class="form-group">
+    <label for="exampleInputPassword1">Password</label>
+    <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+  </div>
+  <div class="form-group">
+    <label for="exampleSelect1">Example select</label>
+    <select class="form-control" id="exampleSelect1">
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="exampleSelect2">Example multiple select</label>
+    <select multiple class="form-control" id="exampleSelect2">
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="exampleTextarea">Example textarea</label>
+    <textarea class="form-control" id="exampleTextarea" rows="3"></textarea>
+  </div>
+  <div class="form-group">
+    <label for="exampleInputFile">File input</label>
+    <input type="file" class="form-control-file" id="exampleInputFile" aria-describedby="fileHelp">
+    <small id="fileHelp" class="form-text text-muted">This is some placeholder block-level help text for the above input. It's a bit lighter and easily wraps to a new line.</small>
+  </div>
+  <fieldset class="form-group">
+    <legend>Radio buttons</legend>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input type="radio" class="form-check-input" name="optionsRadios" id="optionsRadios1" value="option1" checked>
+        Option one is this and that&mdash;be sure to include why it's great
+      </label>
+    </div>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input type="radio" class="form-check-input" name="optionsRadios" id="optionsRadios2" value="option2">
+        Option two can be something else and selecting it will deselect option one
+      </label>
+    </div>
+    <div class="form-check disabled">
+      <label class="form-check-label">
+        <input type="radio" class="form-check-input" name="optionsRadios" id="optionsRadios3" value="option3" disabled>
+        Option three is disabled
+      </label>
+    </div>
+  </fieldset>
+  <div class="form-check">
+    <label class="form-check-label">
+      <input type="checkbox" class="form-check-input">
+      Check me out
+    </label>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>

--- a/test/formatting-html-only/samples/openging-at-end.html
+++ b/test/formatting-html-only/samples/openging-at-end.html
@@ -1,0 +1,29 @@
+<p
+  >Want to write us a letter? Use our<a
+    ><b
+      ><a>mailing address</a></b
+    ></a
+  >.</p
+>
+
+<p
+  >Want to write us a letter? Use our<a
+  href="contacts.html#Mailing_address"
+    ><b
+      ><a>mailing address</a></b
+    ></a
+  >.</p
+>
+
+<p
+  >Want to write us a letter? Use our<a
+  href="contacts.html#Mailing_address"
+  href1="contacts.html#Mailing_address"
+  href2="contacts.html#Mailing_address"
+  href3="contacts.html#Mailing_address"
+  href4="contacts.html#Mailing_address"
+    ><b
+      ><a>mailing address</a></b
+    ></a
+  >.</p
+>

--- a/test/formatting-html-only/samples/pre.html
+++ b/test/formatting-html-only/samples/pre.html
@@ -1,0 +1,80 @@
+<pre>
+--------------------------------------------------------------------------------
+
+
+                                      *         *       *
+                                     **        **      ***
+                                     **        **       *
+   ****    ***  ****               ********  ********                   ***  ****
+  * ***  *  **** **** *    ***    ********  ********  ***        ***     **** **** *
+ *   ****    **   ****    * ***      **        **      ***      * ***     **   ****
+**    **     **          *   ***     **        **       **     *   ***    **
+**    **     **         **    ***    **        **       **    **    ***   **
+**    **     **         ********     **        **       **    ********    **
+**    **     **         *******      **        **       **    *******     **
+**    **     **         **           **        **       **    **          **
+*******      ***        ****    *    **        **       **    ****    *   ***
+******        ***        *******      **        **      *** *  *******     ***
+**                        *****                          ***    *****
+**
+**
+ **
+
+--------------------------------------------------------------------------------
+</pre>
+<pre>
+
+        Text in a pre element
+
+    is displayed in a fixed-width
+
+   font, and it preserves
+
+   both             spaces and
+
+   line breaks
+
+</pre>
+<pre>     Foo     Bar     </pre>
+<pre>
+     Foo     Bar
+</pre>
+<pre>Foo     Bar
+</pre>
+<pre>
+     Foo     Bar</pre>
+<figure role="img" aria-labelledby="cow-caption">
+  <pre>
+___________________________
+< I'm an expert in my field. >
+---------------------------
+     \   ^__^
+      \  (oo)\_______
+         (__)\       )\/\
+             ||----w |
+             ||     ||
+___________________________
+  </pre>
+  <figcaption id="cow-caption">
+    A cow saying, "I'm an expert in my field." The cow is illustrated using preformatted text characters.
+  </figcaption>
+</figure>
+<pre data-attr-1="foo" data-attr-2="foo" data-attr-3="foo" data-attr-4="foo" data-attr-5="foo" data-attr-6="foo">
+     Foo     Bar
+</pre>
+<div>
+  <div>
+    <div>
+      <div>
+        <pre>
+          ______
+          STRING
+          ______
+        </pre>
+      </div>
+    </div>
+  </div>
+</div>
+<pre></pre>
+
+<pre><code #foo></code></pre>

--- a/test/formatting-html-only/samples/tags.html
+++ b/test/formatting-html-only/samples/tags.html
@@ -1,0 +1,115 @@
+<br/>
+<br />
+<br  />
+<br
+/>
+<br attribute-a />
+<br very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-attribute />
+<br attribute-a="value" />
+<br
+  attribute-a="value"
+/>
+<br very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-attribute="value" />
+<br very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-attribute="very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-value" />
+<br attribute-a="value" attribute-b="value" attribute-c="value" attribute-d="value" attribute-e="value" attribute-f="value" />
+<div>string</div>
+<div>very very very very very very very very very very very very very very very very long string</div>
+<div very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-attribute>string</div>
+<div very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-attribute="value">string</div>
+<div attribute="very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-value">string</div>
+<div attribute="value">very very very very very very very very very very very very very very very very long string</div>
+<div attribute="value" attributea="value" attributeb="value" attributec="value" attributed="value" attributef="value">string</div>
+<div attribute="value" attributea="value" attributeb="value" attributec="value" attributed="value" attributef="value">very very very very very very very very very very very very very very very very long string</div>
+<video width="320" height="240" controls>
+  <source src="movie.mp4" type="video/mp4">
+  <source src="movie.ogg" type="video/ogg">
+  Your browser does not support the video tag.
+</video>
+<div><div>string</div></div>
+<div><div>string</div><div>string</div></div>
+<div><div><div>string</div></div><div>string</div></div>
+<div><div>string</div><div><div>string</div></div></div>
+<div><div></div></div>
+<div><div></div><div></div></div>
+<div><div><div><div><div><div><div>string</div></div></div></div></div></div></div>
+<div>
+  <div>string</div>
+</div>
+<div>
+
+  <div>string</div>
+
+</div>
+<div>
+
+  <div>string</div>
+
+  <div>string</div>
+
+</div>
+<ul
+  >123<li
+    class="foo"
+    id="bar"
+  >First</li
+  >456<li
+    class="baz"
+  >Second</li
+  >789</ul
+>
+<span>*<b>200</b></span>
+<img src="longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong" />123
+<div>123<meta attr/>456</div>
+<p>x<span a="b"></span></p>
+<p>x<meta a></p>
+<p>x<meta></p>
+<span></span>
+
+<label aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa></label> |
+<span></span>
+<br />
+<button xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  >12345678901234567890</button
+> <br /><br />
+
+<button bind-disabled="isUnchanged" on-click="onSave($event)"
+  >Disabled Cancel</button
+>
+<br /><br />
+<button xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  >12345678901234567890</button
+> <br /><br />
+
+<button bind-disabled="isUnchanged" on-click="onSave($event)"
+  >Disabled Cancel</button
+>
+<br /><br />
+<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
+<li>12345678901234567890123456789012345678901234567890123456789012345678901234567890</li>
+<div>
+<app-nav></app-nav>
+<router-outlet></router-outlet>
+<app-footer></app-footer>
+
+<app-nav [input]="something"></app-nav>
+<router-outlet></router-outlet>
+<app-footer></app-footer>
+
+<app-primary-navigation></app-primary-navigation>
+<router-outlet></router-outlet>
+<app-footer [input]="something"></app-footer>
+</div>
+<x:root><SPAN>foreign tag name should not be lower cased</SPAN></x:root>
+<div>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+  "<strong>seddoeiusmod</strong>".
+</div>
+<div>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+  <strong>seddoeiusmod</strong>.
+</div>
+<span>
+  <i class="fa fa-refresh fa-spin" />
+  <i class="fa fa-refresh fa-spin" />
+  <i class="fa fa-refresh fa-spin" />
+</span>

--- a/test/formatting-html-only/samples/textarea.html
+++ b/test/formatting-html-only/samples/textarea.html
@@ -1,0 +1,30 @@
+<div>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <div>
+                      <div>
+                        <textarea rows="10" cols="45" name="text">
+                        String
+                        </textarea>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<textarea></textarea>
+
+<div><textarea>lorem ipsum</textarea></div>


### PR DESCRIPTION
Main idea of this PR:

**If you use only HTML without Svelte stuff then result should be same with `html` parser/printer**

So I wrote a one test suite for it and copy few samples from [prettier tests](https://github.com/prettier/prettier/tree/master/tests).

This tests are red, because now we have differents and bugs also - but I think we should make they green? And they should be green with default options in config?