### PR TITLE
don't force a quoting style on the user (#94)

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -18,8 +18,7 @@ export function embed(
     if (node.isJS) {
         return removeLines(
             textToDoc(getText(node, options), {
-                parser: expressionParser,
-                singleQuote: true,
+                parser: expressionParser
             }),
         );
     }

--- a/test/printer/samples/each-block-else-with-nested-if-block-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block-else.html
@@ -1,7 +1,7 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}
+    {#if type === "dog"}
         <p>no dogs</p>
     {:else}
         <p>no animals</p>

--- a/test/printer/samples/each-block-else-with-nested-if-block-elseif-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block-elseif-else.html
@@ -1,9 +1,9 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}
+    {#if type === "dog"}
         <p>no dogs</p>
-    {:else if type === 'cat'}
+    {:else if type === "cat"}
         <p>no cats</p>
     {:else}
         <p>no animals</p>

--- a/test/printer/samples/each-block-else-with-nested-if-block-elseif.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block-elseif.html
@@ -1,9 +1,9 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}
+    {#if type === "dog"}
         <p>no dogs</p>
-    {:else if type === 'cat'}
+    {:else if type === "cat"}
         <p>no cats</p>
     {/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-block.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block.html
@@ -1,7 +1,7 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}
+    {#if type === "dog"}
         <p>no dogs</p>
     {/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-else.html
@@ -1,5 +1,5 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}no dogs{:else}no animals{/if}
+    {#if type === "dog"}no dogs{:else}no animals{/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-elseif-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-elseif-else.html
@@ -1,7 +1,7 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}
+    {#if type === "dog"}
         no dogs
-    {:else if type === 'cat'}no cats{:else}no animals{/if}
+    {:else if type === "cat"}no cats{:else}no animals{/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-elseif.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-elseif.html
@@ -1,5 +1,5 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}no dogs{:else if type === 'cat'}no cats{/if}
+    {#if type === "dog"}no dogs{:else if type === "cat"}no cats{/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline.html
@@ -1,5 +1,5 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}no dogs{/if}
+    {#if type === "dog"}no dogs{/if}
 {/each}

--- a/test/printer/samples/unicode-mustache.html
+++ b/test/printer/samples/unicode-mustache.html
@@ -1,1 +1,1 @@
-<div>{'Lønn'}</div>
+<div>{"Lønn"}</div>


### PR DESCRIPTION
It looks like the very first cut of the plugin had this set, so it was probably grandfathered in from the early days.  In my testing with this change, the plugin respects the setting of `singleQuote` in my local .prettierrc.yml file.