### PR TITLE
Keep comments in event handlers

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -44,6 +44,7 @@ function expressionParser(text: string, parsers: any) {
     return {
         type: 'File',
         program: ast.program.body[0].expression,
+        comments: ast.comments,
     };
 }
 

--- a/test/printer/samples/event-handler-with-comment.html
+++ b/test/printer/samples/event-handler-with-comment.html
@@ -1,0 +1,6 @@
+<button
+    on:click={() => {
+        /* Event handler with comment */
+    }}>
+    toggle
+</button>


### PR DESCRIPTION
Fixes #96. Includes test that failed before, but is green now.