### PR TITLE
Add option to disable first level of indent in script and style tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ and add your preferred configuration options:
 
 - **`svelteIndentScriptAndStyle`**
   - Default: `true`
-  - Indent the contents of script and style tags inside component files (svelte equivalent of [vueIndentScriptAndStyle](https://prettier.io/docs/en/options.html#vue-files-script-and-style-tags-indentation))
+  - Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files. This saves an indentation level, but might break code folding in your editor.
 
   For example:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ and add your preferred configuration options:
   - Default: `false`
   - Put the `>` of a multiline element on a new line (svelte equivalent of [jsxBracketSameLine](https://prettier.io/docs/en/options.html#jsx-brackets) rule)
 
+- **`svelteIndentScriptAndStyle`**
+  - Default: `true`
+  - Indent the contents of script and style tags inside component files (svelte equivalent of [vueIndentScriptAndStyle](https://prettier.io/docs/en/options.html#vue-files-script-and-style-tags-indentation))
+
   For example:
 
   ```html
@@ -58,7 +62,8 @@ and add your preferred configuration options:
   "svelteSortOrder" : "styles-scripts-markup",
   "svelteStrictMode": true,
   "svelteBracketNewLine": true,
-  "svelteAllowShorthand": false
+  "svelteAllowShorthand": false,
+  "svelteIndentScriptAndStyle": false
 }
 ```
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -24,14 +24,15 @@ export function embed(
         );
     }
 
+    const indentContent = options.svelteIndentScriptAndStyle;
     switch (node.type) {
         case 'Script':
-            return embedTag('script', path, print, textToDoc, node, false, options);
+            return embedTag('script', path, print, textToDoc, node, false, indentContent);
         case 'Style':
-            return embedTag('style', path, print, textToDoc, node, false, options);
+            return embedTag('style', path, print, textToDoc, node, false, indentContent);
         case 'Element': {
             if (node.name === 'script' || node.name === 'style') {
-                return embedTag(node.name, path, print, textToDoc, node, true, options);
+                return embedTag(node.name, path, print, textToDoc, node, true, indentContent);
             }
         }
     }
@@ -92,7 +93,7 @@ function embedTag(
     textToDoc: (text: string, options: object) => Doc,
     node: Node & { attributes: Node[] },
     inline: boolean,
-    options: ParserOptions,
+    indentContent: boolean,
 ) {
     const parser = tag === 'script' ? 'typescript' : 'css';
     const contentAttribute = (node.attributes as AttributeNode[]).find(
@@ -117,7 +118,7 @@ function embedTag(
             tag,
             indent(group(concat(path.map(childPath => childPath.call(print), 'attributes')))),
             '>',
-            options.svelteIndentScriptAndStyle ? indent(docContent) : docContent,
+            indentContent ? indent(docContent) : docContent,
             hardline,
             '</',
             tag,

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -26,12 +26,12 @@ export function embed(
 
     switch (node.type) {
         case 'Script':
-            return embedTag('script', path, print, textToDoc, node);
+            return embedTag('script', path, print, textToDoc, node, false, options);
         case 'Style':
-            return embedTag('style', path, print, textToDoc, node);
+            return embedTag('style', path, print, textToDoc, node, false, options);
         case 'Element': {
             if (node.name === 'script' || node.name === 'style') {
-                return embedTag(node.name, path, print, textToDoc, node, true)
+                return embedTag(node.name, path, print, textToDoc, node, true, options);
             }
         }
     }
@@ -92,6 +92,7 @@ function embedTag(
     textToDoc: (text: string, options: object) => Doc,
     node: Node & { attributes: Node[] },
     inline: boolean,
+    options: ParserOptions,
 ) {
     const parser = tag === 'script' ? 'typescript' : 'css';
     const contentAttribute = (node.attributes as AttributeNode[]).find(
@@ -108,13 +109,15 @@ function embedTag(
     }
     node.attributes = node.attributes.filter(n => n !== contentAttribute);
 
+    const docContent = concat([hardline, nukeLastLine(textToDoc(content, { parser }))]);
+
     return group(
         concat([
             '<',
             tag,
             indent(group(concat(path.map(childPath => childPath.call(print), 'attributes')))),
             '>',
-            indent(concat([hardline, nukeLastLine(textToDoc(content, { parser }))])),
+            options.svelteIndentScriptAndStyle ? indent(docContent) : docContent,
             hardline,
             '</',
             tag,

--- a/src/options.ts
+++ b/src/options.ts
@@ -44,7 +44,7 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
     svelteIndentScriptAndStyle: {
         type: 'boolean',
         default: true,
-        description: 'Indent the contents of script and style tags inside component files',
+        description: 'Whether or not to indent the code inside <script> and <style> tags in Svelte files',
     },
 };
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,6 +9,7 @@ export interface PluginOptions {
     svelteStrictMode: boolean;
     svelteBracketNewLine: boolean;
     svelteAllowShorthand: boolean;
+    svelteIndentScriptAndStyle: boolean;
 }
 
 export const options: Record<keyof PluginOptions, SupportOption> = {
@@ -39,6 +40,11 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
         type: 'boolean',
         default: true,
         description: 'Option to enable/disable component attribute shorthand if attribute name and expressions are same',
+    },
+    svelteIndentScriptAndStyle: {
+        type: 'boolean',
+        default: true,
+        description: 'Indent the contents of script and style tags inside component files',
     },
 };
 

--- a/test/printer/samples/indent-script-and-style.html
+++ b/test/printer/samples/indent-script-and-style.html
@@ -1,0 +1,11 @@
+<script>
+let x = 5;
+</script>
+
+<style>
+div::after {
+    content: "No indent";
+}
+</style>
+
+<div />

--- a/test/printer/samples/indent-script-and-style.options.json
+++ b/test/printer/samples/indent-script-and-style.options.json
@@ -1,0 +1,3 @@
+{
+    "svelteIndentScriptAndStyle": false
+}


### PR DESCRIPTION
Closes #105 

Add a new option to the plugin to disable the first level of indent in script and style tags. Equivalent of [vueIndentScriptAndStyle](https://prettier.io/docs/en/options.html#vue-files-script-and-style-tags-indentation).