### PR TITLE
Always give the body of #each, :else and #if tags an own line 

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -113,7 +113,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 return '';
             }
 
-            return concat([printChildren(path, print, false), hardline]);
+            return concat([printChildren(path, print, null), hardline]);
         case 'Text':
             if (isEmptyNode(node)) {
                 return {
@@ -249,7 +249,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 '{#if ',
                 printJS(path, print, 'expression'),
                 '}',
-                indent(printChildren(path, print)),
+                indent(printChildren(path, print, hardline)),
             ];
 
             if (node.else) {
@@ -274,7 +274,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                     '{:else if ',
                     path.map(ifPath => printJS(path, print, 'expression'), 'children')[0],
                     '}',
-                    indent(path.map(ifPath => printChildren(ifPath, print), 'children')[0]),
+                    indent(path.map(ifPath => printChildren(ifPath, print, hardline), 'children')[0]),
                 ];
 
                 if (ifNode.else) {
@@ -283,7 +283,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 return group(concat(def));
             }
 
-            return group(concat(['{:else}', indent(printChildren(path, print))]));
+            return group(concat(['{:else}', indent(printChildren(path, print, hardline))]));
         }
         case 'EachBlock': {
             const def: Doc[] = [
@@ -301,7 +301,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 def.push(' (', printJS(path, print, 'key'), ')');
             }
 
-            def.push('}', indent(printChildren(path, print)));
+            def.push('}', indent(printChildren(path, print, hardline)));
 
             if (node.else) {
                 def.push(path.call(print, 'else'));
@@ -552,7 +552,7 @@ function trimRight(group: Doc[]): void {
     last.parts.reverse();
 }
 
-function printChildren(path: FastPath, print: PrintFn, surroundingLines = true): Doc {
+function printChildren(path: FastPath, print: PrintFn, surroundingLines: Doc|null = softline): Doc {
     const childDocs: Doc[] = [];
     let currentGroup: Doc[] = [];
 
@@ -587,9 +587,9 @@ function printChildren(path: FastPath, print: PrintFn, surroundingLines = true):
     flush();
 
     return concat([
-        surroundingLines ? softline : '',
+        surroundingLines || '',
         join(hardline, childDocs),
-        surroundingLines ? dedent(softline) : '',
+        surroundingLines ? dedent(surroundingLines) : '',
     ]);
 }
 

--- a/test/printer/samples/each-block-else-with-nested-if-inline-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-else.html
@@ -1,5 +1,9 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}no dogs{:else}no animals{/if}
+    {#if type === 'dog'}
+        no dogs
+    {:else}
+        no animals
+    {/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-elseif-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-elseif-else.html
@@ -3,5 +3,9 @@
 {:else}
     {#if type === 'dog'}
         no dogs
-    {:else if type === 'cat'}no cats{:else}no animals{/if}
+    {:else if type === 'cat'}
+        no cats
+    {:else}
+        no animals
+    {/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-elseif.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-elseif.html
@@ -1,5 +1,9 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}no dogs{:else if type === 'cat'}no cats{/if}
+    {#if type === 'dog'}
+        no dogs
+    {:else if type === 'cat'}
+        no cats
+    {/if}
 {/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline.html
@@ -1,5 +1,7 @@
 {#each animals as animal}
     <p>{animal}</p>
 {:else}
-    {#if type === 'dog'}no dogs{/if}
+    {#if type === 'dog'}
+        no dogs
+    {/if}
 {/each}

--- a/test/printer/samples/each-inline-else.html
+++ b/test/printer/samples/each-inline-else.html
@@ -1,1 +1,5 @@
-{#each animals as animal}{animal}{:else}no animals{/each}
+{#each animals as animal}
+    {animal}
+{:else}
+    no animals
+{/each}

--- a/test/printer/samples/each-inline-indexed.html
+++ b/test/printer/samples/each-inline-indexed.html
@@ -1,1 +1,3 @@
-{#each animals as animal, i}{i}: {animal}{/each}
+{#each animals as animal, i}
+    {i}: {animal}
+{/each}

--- a/test/printer/samples/each-inline-keyed.html
+++ b/test/printer/samples/each-inline-keyed.html
@@ -1,1 +1,3 @@
-{#each todos as todo (todo.id)}{todo}{/each}
+{#each todos as todo (todo.id)}
+    {todo}
+{/each}

--- a/test/printer/samples/each-inline.html
+++ b/test/printer/samples/each-inline.html
@@ -1,1 +1,3 @@
-{#each animals as animal}{animal}{/each}
+{#each animals as animal}
+    {animal}
+{/each}

--- a/test/printer/samples/if-inline-else.html
+++ b/test/printer/samples/if-inline-else.html
@@ -1,1 +1,5 @@
-{#if foo}bar{:else}baz{/if}
+{#if foo}
+    bar
+{:else}
+    baz
+{/if}

--- a/test/printer/samples/if-inline-elseif-else.html
+++ b/test/printer/samples/if-inline-elseif-else.html
@@ -1,1 +1,7 @@
-{#if foo}bar{:else if baz}qux{:else}foobar{/if}
+{#if foo}
+    bar
+{:else if baz}
+    qux
+{:else}
+    foobar
+{/if}

--- a/test/printer/samples/if-inline-elseif.html
+++ b/test/printer/samples/if-inline-elseif.html
@@ -1,1 +1,5 @@
-{#if foo}bar{:else if baz}qux{/if}
+{#if foo}
+    bar
+{:else if baz}
+    qux
+{/if}

--- a/test/printer/samples/if-inline.html
+++ b/test/printer/samples/if-inline.html
@@ -1,1 +1,3 @@
-{#if foo}bar{/if}
+{#if foo}
+    bar
+{/if}


### PR DESCRIPTION
…rather than putting it all on a single line.

I guess there is scope for debate on whether this change should really be made or not, but since the PR is pretty trivial I'll submit one and leave it for others to debate. 

For what it's worth, I'd agree this is more readable (though I also think the whitespace handling is unexpected; I'd expect `{#each numbers as number}{number}, {/each}` to produce `1, 2, 3, ` rather than `1,2,3,`).

Fixes #117 