### PR TITLE
Incorrectly escaped regexp broke style tags followed by "s"

### DIFF
--- a/src/lib/snipTagContent.ts
+++ b/src/lib/snipTagContent.ts
@@ -1,5 +1,5 @@
 export function snipTagContent(tagName: string, source: string, placeholder = ''): string {
-    const regex = new RegExp(`[\s\n]*<${tagName}([^]*?)>([^]*?)<\/${tagName}>[\s\n]*`, 'gi');
+    const regex = new RegExp(`[\\s\n]*<${tagName}([^]*?)>([^]*?)<\/${tagName}>[\\s\n]*`, 'gi');
     return source.replace(regex, (_, attributes, content) => {
         const encodedContent = Buffer.from(content).toString('base64');
         return `<${tagName}${attributes} ✂prettier:content✂="${encodedContent}">${placeholder}</${tagName}>`;

--- a/test/printer/samples/s-after-style-tag.html
+++ b/test/printer/samples/s-after-style-tag.html
@@ -1,0 +1,5 @@
+<style>
+
+</style>
+
+sssssweet

--- a/test/printer/samples/script-inside-comment.html
+++ b/test/printer/samples/script-inside-comment.html
@@ -1,1 +1,1 @@
-<!-- <script>alert(1)</script> -->
+<!--<script>alert(1)</script>-->

--- a/test/printer/samples/style-inside-comment.html
+++ b/test/printer/samples/style-inside-comment.html
@@ -1,1 +1,1 @@
-<!-- <style>div { color: red }</style> -->
+<!--<style>div { color: red }</style>-->


### PR DESCRIPTION
If there was the letter "s" after a `<style>` block, it would be trimmed.

Because the regexp is inside backticks `\s` will be interpreted as just an "s" with an unnecessary quote. It needs double-quoting for the regexp to receive it as `\s` (note that the same does not apply for `\n` because it's just turned into a newline by the backticks and passed as such to regexp which is fine).

Compare

```
> ' s'.match(new RegExp('\s'))
[ 's', index: 1, input: ' s\t', groups: undefined ]
> ' s'.match(new RegExp('\\s'))
[ ' ', index: 0, input: ' s\t', groups: undefined ]
```

Fixes #118 