### PR TITLE
(fix) Make isASTNode function work with prettier 2.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .vscode
+.history
 plugin.js
 plugin.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,9 +412,9 @@
             "dev": true
         },
         "@types/prettier": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.0.tgz",
-            "integrity": "sha512-/rM+sWiuOZ5dvuVzV37sUuklsbg+JPOP8d+nNFlo2ZtfpzPiPvh1/gc8liWOLBqe+sR+ZM7guPaIcTt6UZTo7Q==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
+            "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
             "dev": true
         },
         "acorn": {
@@ -3530,9 +3530,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.0.tgz",
+            "integrity": "sha512-lz28cCbA1cDFHVuY8vvj6QuqOwIpyIfPUYkSl8AZ/vxH8qBXMMjE2knfLHCrZCmUsK/H1bg1P0tOo0dJkTJHvw==",
             "dev": true
         },
         "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "homepage": "https://github.com/sveltejs/prettier-plugin-svelte#readme",
     "devDependencies": {
         "@types/node": "^10.12.18",
-        "@types/prettier": "^2.0.0",
+        "@types/prettier": "^2.0.2",
         "ava": "1.2.0",
-        "prettier": "^2.0.0",
+        "prettier": "^2.1.0",
         "rollup": "1.1.2",
         "rollup-plugin-commonjs": "9.2.0",
         "rollup-plugin-node-resolve": "4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { SupportLanguage, Parser, Printer } from 'prettier';
 import { print } from './print';
+import { ASTNode } from './print/nodes';
 import { embed } from './embed';
 import { snipTagContent } from './lib/snipTagContent';
 
@@ -21,9 +22,9 @@ export const languages: Partial<SupportLanguage>[] = [
 
 export const parsers: Record<string, Parser> = {
     svelte: {
-        parse: text => {
+        parse: (text) => {
             try {
-                return require(`svelte/compiler`).parse(text);
+                return <ASTNode>{ ...require(`svelte/compiler`).parse(text), __isRoot: true };
             } catch (err) {
                 err.loc = {
                     start: err.start,
@@ -34,7 +35,7 @@ export const parsers: Record<string, Parser> = {
                 throw err;
             }
         },
-        preprocess: text => {
+        preprocess: (text) => {
             text = snipTagContent('style', text);
             text = snipTagContent('script', text, '{}');
             return text.trim();

--- a/src/print/helpers.ts
+++ b/src/print/helpers.ts
@@ -1,19 +1,9 @@
-import { Node, ScriptNode, InstanceScriptNode, ModuleScriptNode } from './nodes';
+import { ASTNode } from './nodes';
 
-export interface ASTNode {
-    html: Node;
-    css?: Node & {
-        attributes: Node[];
-        children: Node[];
-        content: Node & {
-            styles: string;
-        };
-    };
-    js?: ScriptNode;
-    instance?: ScriptNode;
-    module?: ScriptNode;
-}
-
+/**
+ * Determines whether or not given node
+ * is the root of the Svelte AST.
+ */
 export function isASTNode(n: any): n is ASTNode {
-    return 'html' in n && 'tokens' in n;
+    return n && n.__isRoot;
 }

--- a/src/print/nodes.ts
+++ b/src/print/nodes.ts
@@ -285,3 +285,26 @@ export type Node =
     | ModuleScriptNode
     | BodyNode
     | OptionsNode;
+
+/**
+ * The Svelte AST root node
+ */
+export interface ASTNode {
+    html: Node;
+    css?: Node & {
+        attributes: Node[];
+        children: Node[];
+        content: Node & {
+            styles: string;
+        };
+    };
+    js?: ScriptNode;
+    instance?: ScriptNode;
+    module?: ScriptNode;
+    /**
+     * This is not actually part of the Svelte parser output,
+     * but we add it afterwards to make sure we can distinguish
+     * the root node from other nodes afterwards.
+     */
+    __isRoot: boolean;
+}


### PR DESCRIPTION
This change alters the code such that we are independent of property-changes of both Svelte and Prettier by adding a `__isRoot`-property to the parser output root.
Fixes #123