### PR TITLE
send debug info to stderr instead of stdout

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -459,7 +459,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
             return concat([line, '{...', printJS(path, print, 'expression'), '}']);
     }
 
-    console.log(JSON.stringify(node, null, 4));
+    console.error(JSON.stringify(node, null, 4));
     throw new Error('unknown node type: ' + node.type);
 }
 
@@ -642,6 +642,6 @@ function expandNode(node): string {
             return ' ...' + node.argument.name;
     }
 
-    console.log(JSON.stringify(node, null, 4));
+    console.error(JSON.stringify(node, null, 4));
     throw new Error('unknown node type: ' + node.type);
 }


### PR DESCRIPTION
Dumping the AST with `console.log` breaks workflow in environments that expect a prettified file on stdout.