### PR TITLE
Handle comments in event handlers

### DIFF
--- a/src/lib/getText.ts
+++ b/src/lib/getText.ts
@@ -2,5 +2,14 @@ import { ParserOptions } from 'prettier';
 import { Node } from '../print/nodes';
 
 export function getText(node: Node, options: ParserOptions) {
-    return options.originalText.slice(options.locStart(node), options.locEnd(node));
+    const leadingComments: Node[] = (node as any).leadingComments
+
+    return options.originalText.slice(
+        options.locStart(
+            // if there are comments before the node they are not included 
+            // in the `start` of the node itself
+            leadingComments && leadingComments[0] || node,
+        ),
+        options.locEnd(node),
+    );
 }

--- a/test/printer/samples/event-handler-comments.html
+++ b/test/printer/samples/event-handler-comments.html
@@ -1,0 +1,6 @@
+<button
+    on:click={// comment
+    () => {
+        /* another comment */
+        fn();
+    }} />


### PR DESCRIPTION
Fixes #96: preserve comments in event handlers.
