### PR TITLE
add vscodeLanguageIds for vscode consumers, this includes coc-prettier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export const languages: Partial<SupportLanguage>[] = [
         name: 'svelte',
         parsers: ['svelte'],
         extensions: ['.svelte'],
+        vscodeLanguageIds: ['svelte'],
     },
 ];
 


### PR DESCRIPTION
coc-prettier relies on `vscodeLanguageIds` to identify a prettier plugin to perform automatic file format on specific triggers (e.g. format on file save). Source: https://github.com/neoclide/coc-prettier/blob/master/src/utils.ts#L68.

This property is also used across multiple official prettier plugins:
- html / vue https://github.com/prettier/prettier/blob/master/src/language-html/index.js#L7
- css https://github.com/prettier/prettier/blob/master/src/language-css/index.js#L7
- js https://github.com/prettier/prettier/blob/master/src/language-js/index.js#L8

This property is also used in vscode-prettier: https://github.com/prettier/prettier-vscode/blob/main/src/LanguageResolver.ts#L37 .