### PR TITLE
Preserve top-level comments

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -62,7 +62,7 @@ export function embed(
 }
 
 function forceIntoExpression(statement: string) {
-    // note the trailing newline: if the statement ends in a // comment, 
+    // note the trailing newline: if the statement ends in a // comment,
     // we can't add the closing bracket right afterwards
     return `(${statement}\n)`;
 }
@@ -169,10 +169,12 @@ function embedTag(
 ) {
     const node: Node = path.getNode();
     const content = getSnippedContent(node);
-    const isIgnored = isIgnoreDirective(getPreviousNode(path));
+
+    const previousNode = getPreviousNode(path);
+    const previousComment = previousNode && previousNode.type === 'Comment' ? previousNode : null;
 
     const body: Doc =
-        isNodeSupportedLanguage(node) && !isIgnored
+        isNodeSupportedLanguage(node) && !isIgnoreDirective(previousComment)
             ? content.trim() !== ''
                 ? formatBodyContent(content)
                 : hardline
@@ -194,10 +196,10 @@ function embedTag(
 
     if (isTopLevel) {
         // top level embedded nodes have been moved from their normal position in the
-        // node tree. if there is an ignore directive referring to it, it must be
-        // recreated at the new position.
-        if (isIgnored) {
-            result = concat(['<!-- prettier-ignore -->', hardline, result]);
+        // node tree. if there is a comment referring to it, it must be recreated at
+        // the new position.
+        if (previousComment) {
+            result = concat(['<!--', previousComment.data, '-->', hardline, result, hardline]);
         } else {
             result = concat([result, hardline]);
         }

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -60,7 +60,7 @@ export function isInlineNode(node: Node): boolean {
     }
 }
 
-export function isNodeWithChildren(node: Node): node is (Node & {children: Node[]}) {
+export function isNodeWithChildren(node: Node): node is Node & { children: Node[] } {
     return (node as any).children;
 }
 
@@ -96,11 +96,28 @@ export function getNextNode(path: FastPath): Node | undefined {
     return getChildren(parent).find((child) => child.start === node.end);
 }
 
+/**
+ * Returns the position that used to be the end of the node before the embed elements were cut out. 
+ */
+export function getNodeEnd(node: Node, path: FastPath) {
+    const root = path.stack[0];
+
+    if (root.html === node) {
+        return Math.max(
+            ...([root.css, root.html, root.instance, root.js, root.module] as Node[])
+                .filter((n) => !!n)
+                .map((n) => n.end),
+        );
+    } else {
+        return node.end;
+    }
+}
+
 export function isEmptyNode(node: Node): boolean {
     return node.type === 'Text' && (node.raw || node.data).trim() === '';
 }
 
-export function isIgnoreDirective(node: Node | undefined): boolean {
+export function isIgnoreDirective(node: Node | undefined | null): boolean {
     return !!node && node.type === 'Comment' && node.data.trim() === 'prettier-ignore';
 }
 

--- a/test/formatting/samples/top-level-comments/input.html
+++ b/test/formatting/samples/top-level-comments/input.html
@@ -1,0 +1,10 @@
+<!-- add your styles here -->
+<style>
+</style>
+
+<!-- here's the actual HTML -->
+<h1>Title</h1>
+
+<!-- code goes here -->
+<script>
+</script>

--- a/test/formatting/samples/top-level-comments/output.html
+++ b/test/formatting/samples/top-level-comments/output.html
@@ -1,0 +1,10 @@
+<!-- code goes here -->
+<script>
+</script>
+
+<!-- add your styles here -->
+<style>
+</style>
+
+<!-- here's the actual HTML -->
+<h1>Title</h1>


### PR DESCRIPTION
To fix #137, if there are comments on a `style`, `script` or `template` tag, keep them together with the following tag when reformatting.

e.g. format 

```
<!-- add your styles here -->
<style>
</style>

<!-- here's the actual HTML -->
<h1>Title</h1>

<!-- code goes here -->
<script>
</script>
```

to

```
<!-- code goes here -->
<script>
</script>

<!-- add your styles here -->
<style>
</style>

<!-- here's the actual HTML -->
<h1>Title</h1>
```