### PR TITLE
Keep inline elements together even when inside a text

### DIFF
--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -26,6 +26,10 @@ export function canBreakAfter(node: Node) {
             return isWhitespaceChar(node.raw[node.raw.length - 1]);
         case 'Element':
             return !isInlineElement(node);
+        case 'IfBlock':
+        case 'EachBlock':
+        case 'MustacheTag':
+            return false;
         default:
             return true;
     }
@@ -37,6 +41,10 @@ export function canBreakBefore(node: Node) {
             return isWhitespaceChar(node.raw[0]);
         case 'Element':
             return !isInlineElement(node);
+        case 'IfBlock':
+        case 'EachBlock':
+        case 'MustacheTag':
+            return false;
         default:
             return true;
     }

--- a/test/formatting/samples/no-html-whitespace-inside-inline-element/output.html
+++ b/test/formatting/samples/no-html-whitespace-inside-inline-element/output.html
@@ -1,4 +1,8 @@
 <p>
-    <b>Apples</b>, <b>Orange</b>, <b>Bananas</b>, <b>Pineapples</b>, <b>Grapefruit</b>,
+    <b>Apples</b>,
+    <b>Orange</b>,
+    <b>Bananas</b>,
+    <b>Pineapples</b>,
+    <b>Grapefruit</b>,
     <b>Kiwi</b>
 </p>

--- a/test/printer/samples/element-with-text-and-inline-element.html
+++ b/test/printer/samples/element-with-text-and-inline-element.html
@@ -1,4 +1,7 @@
 <div>
-    This text combined with
-    <b>this text is longer than a line, but the second text by itself isn't.</b>
+    <p>
+        This is line A.
+        <b>This is B. len(A + B) &gt; 80+ chars. len(b) lt; 80.</b>
+    </p>
+    <p>This is line A. <b>This is B. len(A + B) &lt; 80 chars.</b></p>
 </div>

--- a/test/printer/samples/element-with-text-and-inline-element.html
+++ b/test/printer/samples/element-with-text-and-inline-element.html
@@ -1,0 +1,4 @@
+<div>
+    This text combined with
+    <b>this text is longer than a line, but the second text by itself isn't.</b>
+</div>


### PR DESCRIPTION
Do:

```
<div>
    This text combined with
    <b>this text is longer than a line, but the second text by itself isn't.</b>
</div>
```

Don't

```
<div>
    This text combined with <b>this text is longer than a line, but the 
        second text by itself isn't.</b>
</div>
```

Fixes #139

The real change in the code is having `extractOutermostNewlines` run on each batched node individually, rather than all of them as a group. This pulls up `line` nodes one level higher, outside of the `flow` they'd otherwise be in. I hope this doesn't have side-effects elsewhere, but I guess we'll expand tests as we find new special cases. There's certainly plenty of those...
