### PR TITLE
add browser support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -740,6 +740,12 @@
                 }
             }
         },
+        "base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "dev": true
+        },
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -804,6 +810,16 @@
                         "is-extendable": "^0.1.0"
                     }
                 }
+            }
+        },
+        "buffer": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
             }
         },
         "buffer-from": {
@@ -2386,6 +2402,12 @@
             "version": "2.8.4",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
             "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "dev": true
         },
         "ignore": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@types/node": "^10.12.18",
         "@types/prettier": "^2.0.2",
         "ava": "1.2.0",
+        "buffer": "^5.6.0",
         "prettier": "^2.1.0",
         "rollup": "1.1.2",
         "rollup-plugin-commonjs": "9.2.0",

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -9,6 +9,7 @@ import {
     getPreviousNode,
 } from './print/node-helpers';
 import { Node } from './print/nodes';
+import { isBrowser, browserBuffer } from './lib/browser';
 
 const {
     builders: { concat, hardline, group, indent, literalline },
@@ -124,6 +125,9 @@ function getSnippedContent(node: Node) {
     const encodedContent = getAttributeTextValue(snippedTagContentAttribute, node);
 
     if (encodedContent) {
+        if (isBrowser) {
+            return browserBuffer.from(encodedContent, 'base64').toString('utf-8');
+        }
         return Buffer.from(encodedContent, 'base64').toString('utf-8');
     } else {
         return '';

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,0 +1,2 @@
+export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+export const browserBuffer = require('buffer/').Buffer;

--- a/src/lib/snipTagContent.ts
+++ b/src/lib/snipTagContent.ts
@@ -1,9 +1,13 @@
+import { isBrowser, browserBuffer } from './browser';
+
 export const snippedTagContentAttribute = '✂prettier:content✂'
 
 export function snipTagContent(tagName: string, source: string, placeholder = ''): string {
     const regex = new RegExp(`[\\s\n]*<${tagName}([^]*?)>([^]*?)<\/${tagName}>[\\s\n]*`, 'gi');
     return source.replace(regex, (_, attributes, content) => {
-        const encodedContent = Buffer.from(content).toString('base64');
+        const encodedContent = isBrowser
+            ? browserBuffer.from(content).toString("base64")
+            : Buffer.from(content).toString("base64");
         return `<${tagName}${attributes} ${snippedTagContentAttribute}="${encodedContent}">${placeholder}</${tagName}>`;
     });
 }
@@ -16,7 +20,9 @@ export function unsnipContent(text: string): string {
     const regex = /(<\w+.*?)\s*✂prettier:content✂="(.*?)">.*?(?=<\/)/gi;
 
     return text.replace(regex, (_, start, encodedContent) => {
-        const content = Buffer.from(encodedContent, 'base64').toString('utf8');
+        const content = isBrowser
+            ? browserBuffer.from(encodedContent, "base64").toString("utf8")
+            : Buffer.from(encodedContent, "base64").toString("utf8");
         return `${start}>${content}`;
     });
 }


### PR DESCRIPTION
This will allow the plugin to use `Buffer` in the browser environment. 
This prevents the `Uncaught ReferenceError: Buffer is not defined` error from being thrown when using `Prettier` in the browser.

With this PR, a Svelte file can be created like below. As noted in the code comments, some further work will need to be done to make this plugin work fully with the browser, which I'm not able to figure out. But this PR will allow others to start using the plugin in the browser and hopefully creating more PRs to make this work. If we're able to do that, then we can start using Prettier formatting in the Svelte REPL.
```
<script>
  import prettier from "prettier";
  import sveltePlugin from "prettier-plugin-svelte";

  let code 
  //this code works as expected
  code = `<div><p>Hello</p>
  <button>World</button></div>`

  //code below throws an error. Uncomment to try it out.  
  //code = "<script>Hello<" + "/" + "script>";

  /*
`code = "<script>Hello<" + "/" + "script>";` will throw 
"Uncaught Error: unknown node type: Script" 
which is from the `print` function inside `index.ts`. 
`index.ts` doesn't have a case to handle Script or Style. 
This will need to be worked on to allow this to be fully used in the browser.
  */

  function format() {
    code = prettier.format(code, {
      parser: "svelte",
      plugins: [sveltePlugin],
    });
  }
</script>

<textarea bind:value={code} style="height:50%; width: 50%; margins: 1em auto" />
<button on:click={format}>FORMAT</button>
```