### PR TITLE
(fix) don't format class attribute

### DIFF
--- a/src/lib/elements.ts
+++ b/src/lib/elements.ts
@@ -77,5 +77,7 @@ export const inlineElements: TagName[] = [
  * HTML attributes that we may safely reformat (trim whitespace, add or remove newlines)
  */
 export const formattableAttributes = [
-  'class'
+  // None at the moment
+  // Prettier HTML does not format attributes at all
+  // and to be consistent we leave this array empty for now
 ]

--- a/test/formatting/samples/attribute-with-linebreaks/output.html
+++ b/test/formatting/samples/attribute-with-linebreaks/output.html
@@ -1,6 +1,5 @@
 <div
-    class="{longExpressionThatForcesLinebreaks} longExpressionThatForcesLinebreaks
-        longExpressionThatForcesLinebreaks"
+    class=" {longExpressionThatForcesLinebreaks} longExpressionThatForcesLinebreaks longExpressionThatForcesLinebreaks  "
     alt="When reformatting class attributes it is fine to trim and add new line breaks. 
 That's not the case with other attributes. "
     data-value={array.map((item) => {


### PR DESCRIPTION
Prettier HTML does not format attributes at all and to be consistent we should not format it, too.