### PR TITLE
(fix) print raw uses original text

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -18,7 +18,7 @@ import {
     isOrCanBeConvertedToShorthand,
     isIgnoreDirective,
     doesEmbedStartAt,
-    getUnencodedText
+    getUnencodedText,
 } from './node-helpers';
 import {
     isLine,
@@ -185,7 +185,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
             if (isEmpty) {
                 body = '';
             } else if (!isSupportedLanguage) {
-                body = printRaw(node);
+                body = printRaw(node, options.originalText);
             } else if (isInlineElement(node) || isPreTagContent(path)) {
                 body = printIndentedPreservingWhitespace(path, print);
             } else {

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -118,6 +118,10 @@ export function printRaw(
     node: ElementNode | InlineComponentNode | SlotNode | WindowNode | HeadNode | TitleNode,
     originalText: string,
 ): string {
+    if (node.children.length === 0) {
+        return '';
+    }
+
     const firstChild = node.children[0];
     const lastChild = node.children[node.children.length - 1];
     return originalText.substring(firstChild.start, lastChild.end);

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -5,6 +5,11 @@ import {
     AttributeNode,
     MustacheTagNode,
     AttributeShorthandNode,
+    HeadNode,
+    InlineComponentNode,
+    SlotNode,
+    TitleNode,
+    WindowNode,
 } from './nodes';
 import { inlineElements, TagName } from '../lib/elements';
 import { FastPath } from 'prettier';
@@ -109,14 +114,13 @@ export function isIgnoreDirective(node: Node | undefined | null): boolean {
     return !!node && node.type === 'Comment' && node.data.trim() === 'prettier-ignore';
 }
 
-export function printRaw(node: Node): string {
-    const children: Node[] | undefined = (node as ElementNode).children;
-
-    if (children) {
-        return children.map(printRaw).join('');
-    } else {
-        return (node as TextNode).raw || '';
-    }
+export function printRaw(
+    node: ElementNode | InlineComponentNode | SlotNode | WindowNode | HeadNode | TitleNode,
+    originalText: string,
+): string {
+    const firstChild = node.children[0];
+    const lastChild = node.children[node.children.length - 1];
+    return originalText.substring(firstChild.start, lastChild.end);
 }
 
 function isTextNode(node: Node): node is TextNode {
@@ -148,7 +152,7 @@ export function getAttributeTextValue(attributeName: string, node: Node): string
 }
 
 function getLangAttribute(node: Node): string | null {
-    const value = getAttributeTextValue('lang', node);
+    const value = getAttributeTextValue('lang', node) || getAttributeTextValue('type', node);
 
     if (value != null) {
         return value.replace(/^text\//, '');

--- a/test/printer/samples/unsupported-language.html
+++ b/test/printer/samples/unsupported-language.html
@@ -16,4 +16,13 @@ alert "This is not valid JS and should not be formatted."
 
   div
     p Hey
+    <p>ok</p>
+</template>
+
+<template type="text/pug">
+  h1 My Title
+
+  div
+    p Hey
+    <p>ok</p>
 </template>


### PR DESCRIPTION
Before that, the tags/attributes within would get erased and only their contents would be preserved.
Also added `type` to the language attribute lookup.