### PR TITLE
Add parsers and options to babel arguments

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -67,8 +67,8 @@ function forceIntoExpression(statement: string) {
     return `(${statement}\n)`;
 }
 
-function expressionParser(text: string, parsers: any) {
-    const ast = parsers.babel(text);
+function expressionParser(text: string, parsers: any, options: any) {
+    const ast = parsers.babel(text, parsers, options);
 
     return { ...ast, program: ast.program.body[0].expression };
 }


### PR DESCRIPTION
I am developing support for tailwind class sorting in my prettier-plugin-tailwind plugin.

My plugin depends on prettier-plugin-svelte and unfortunately prettier-plugin-svelte does not provide the parsers and options to the babel parser, which my tailwind plugin requires.

This change has no changes to the way prettier-plugin-svelte runs and simply provides the information to the babel parser.