### PR TITLE
Fix markdown print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rework of the tag breaking logic with the goal to be more in line with how Prettier formats HTML. This includes respecting the user's decision to have child tags in seperate lines even if they don't exceed the maximum line width ([#143](https://github.com/sveltejs/prettier-plugin-svelte/issues/143), [#117](https://github.com/sveltejs/prettier-plugin-svelte/issues/117)). This is a breaking change because tags are broken up differently now than before.
 * Default sort order is now `scripts-markup-styles`. This is a breaking change.
+* Fix formatting of fenced Svelte code blocks inside markdown ([#129](https://github.com/sveltejs/prettier-plugin-svelte/issues/129))
 
 ## 1.4.2
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export const parsers: Record<string, Parser> = {
                 return <ASTNode>{ ...require(`svelte/compiler`).parse(text), __isRoot: true };
             } catch (err) {
                 if (err.start != null && err.end != null) {
-                    // Prettier expects error objects to have loc.start and loc.end fields. 
+                    // Prettier expects error objects to have loc.start and loc.end fields.
                     // Svelte uses start and end directly on the error.
                     err.loc = {
                         start: err.start,
@@ -39,10 +39,17 @@ export const parsers: Record<string, Parser> = {
                 throw err;
             }
         },
-        preprocess: (text) => {
+        preprocess: (text, options) => {
             text = snipTagContent('style', text);
             text = snipTagContent('script', text, '{}');
-            return text.trim();
+            text = text.trim();
+            // Prettier sets the preprocessed text as the originalText in case
+            // the Svelte formatter is called directly. In case it's called
+            // as an embedded parser (for example when there's a Svelte code block
+            // inside markdown), the originalText is not updated after preprocessing.
+            // Therefore we do it ourselves here.
+            options.originalText = text;
+            return text;
         },
         locStart,
         locEnd,

--- a/test/printer/samples/markdown.md
+++ b/test/printer/samples/markdown.md
@@ -1,0 +1,21 @@
+This is a markdown file with embedded Svelte content. Prettier can format this
+by offloading the formatting of the fenced code block to prettier-plugin-svelte.
+
+```svelte
+<script context="module">
+    const greeting = "Hello";
+</script>
+
+<script>
+    const name = "world";
+</script>
+
+<h1>{greeting}, {name}!</h1>
+
+<style>
+    h1 {
+        color: green;
+    }
+</style>
+
+```


### PR DESCRIPTION
Prettier sets the preprocessed text as the originalText in case the Svelte formatter is called directly. In case it's called as an embedded parser (for example when there's a Svelte code block inside markdown), the originalText is not updated after preprocessing. Therefore we update the originalText ourselves.
Fixes #129