### PR TITLE
Keep lines inside embedded expression

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -12,6 +12,7 @@ import { Node } from './print/nodes';
 
 const {
     builders: { concat, hardline, group, indent, literalline },
+    utils: { removeLines },
 } = doc;
 
 export function embed(
@@ -31,7 +32,8 @@ export function embed(
                 embeddedOptions.singleQuote = true;
             }
 
-            return textToDoc(forceIntoExpression(getText(node, options)), embeddedOptions);
+            const docs = textToDoc(forceIntoExpression(getText(node, options)), embeddedOptions);
+            return node.forceSingleLine ? removeLines(docs) : docs;
         } catch (e) {
             return getText(node, options);
         }

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -12,7 +12,6 @@ import { Node } from './print/nodes';
 
 const {
     builders: { concat, hardline, group, indent, literalline },
-    utils: { removeLines },
 } = doc;
 
 export function embed(
@@ -32,9 +31,7 @@ export function embed(
                 embeddedOptions.singleQuote = true;
             }
 
-            return removeLines(
-                textToDoc(forceIntoExpression(getText(node, options)), embeddedOptions),
-            );
+            return textToDoc(forceIntoExpression(getText(node, options)), embeddedOptions);
         } catch (e) {
             return getText(node, options);
         }

--- a/src/print/nodes.ts
+++ b/src/print/nodes.ts
@@ -3,6 +3,7 @@ export interface BaseNode {
     end: number;
     isJS?: boolean;
     forceSingleQuote?: boolean;
+    forceSingleLine?: boolean;
 }
 
 export interface FragmentNode extends BaseNode {

--- a/test/formatting/samples/long-attribute-value/input.html
+++ b/test/formatting/samples/long-attribute-value/input.html
@@ -1,0 +1,3 @@
+<input
+  type="password"
+  use:trackChanges={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }} />

--- a/test/formatting/samples/long-attribute-value/input.html
+++ b/test/formatting/samples/long-attribute-value/input.html
@@ -1,3 +1,17 @@
 <input
   type="password"
-  use:trackChanges={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }} />
+  use:fits={{ store: passwordStore, clean: [ensureString] }}
+  use:breaks={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }}
+  on:fits={() => ''}
+  on:breaks={() => { const a = ''; a.toLowerCase(); }}
+  in:fits={{ store: passwordStore, clean: [ensureString] }}
+  in:breaks={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }}
+  out:fits={{ store: passwordStore, clean: [ensureString] }}
+  out:breaks={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }}
+  transition:fits={{ store: passwordStore, clean: [ensureString] }}
+  transition:breaks={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }}
+  animate:fits={{ store: passwordStore, clean: [ensureString] }}
+  animate:breaks={{ store: passwordStore, clean: [ensureString], validate: [minLength(6), maxLength(25)] }}
+  class:fits={'short check that fits in one line' ? true : false}
+  class:breaks={'some really long condition check happening here' ? true : false}
+   />

--- a/test/formatting/samples/long-attribute-value/output.html
+++ b/test/formatting/samples/long-attribute-value/output.html
@@ -1,0 +1,7 @@
+<input
+    type="password"
+    use:trackChanges={{
+        store: passwordStore,
+        clean: [ensureString],
+        validate: [minLength(6), maxLength(25)],
+    }} />

--- a/test/formatting/samples/long-attribute-value/output.html
+++ b/test/formatting/samples/long-attribute-value/output.html
@@ -1,7 +1,41 @@
 <input
     type="password"
-    use:trackChanges={{
+    use:fits={{ store: passwordStore, clean: [ensureString] }}
+    use:breaks={{
         store: passwordStore,
         clean: [ensureString],
         validate: [minLength(6), maxLength(25)],
-    }} />
+    }}
+    on:fits={() => ""}
+    on:breaks={() => {
+        const a = "";
+        a.toLowerCase();
+    }}
+    in:fits={{ store: passwordStore, clean: [ensureString] }}
+    in:breaks={{
+        store: passwordStore,
+        clean: [ensureString],
+        validate: [minLength(6), maxLength(25)],
+    }}
+    out:fits={{ store: passwordStore, clean: [ensureString] }}
+    out:breaks={{
+        store: passwordStore,
+        clean: [ensureString],
+        validate: [minLength(6), maxLength(25)],
+    }}
+    transition:fits={{ store: passwordStore, clean: [ensureString] }}
+    transition:breaks={{
+        store: passwordStore,
+        clean: [ensureString],
+        validate: [minLength(6), maxLength(25)],
+    }}
+    animate:fits={{ store: passwordStore, clean: [ensureString] }}
+    animate:breaks={{
+        store: passwordStore,
+        clean: [ensureString],
+        validate: [minLength(6), maxLength(25)],
+    }}
+    class:fits={"short check that fits in one line" ? true : false}
+    class:breaks={"some really long condition check happening here"
+        ? true
+        : false} />

--- a/test/formatting/samples/long-mustache-value/input.html
+++ b/test/formatting/samples/long-mustache-value/input.html
@@ -3,4 +3,4 @@
   class="attributes are not broken up by default which is the prettier behavior but {'breakable' + 'mustache tags'} can be broken up"
    />
 
-<p>Text with spaces inbetween should break at the most fitting point and not wait for a {'breakable' + 'mustache tags'} to be broken up. {'If the mustache tag itself is very long, however' + 'it should be broken uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuup'}</p>
+<p>Text with spaces inbetween should break at the most fitting point and not wait for a {'breakable' + 'mustache tags'} to be broken up. {'If the mustache tag itself is very long, however' + 'it should be broken uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuup'} {andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaakaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}</p>

--- a/test/formatting/samples/long-mustache-value/input.html
+++ b/test/formatting/samples/long-mustache-value/input.html
@@ -1,0 +1,6 @@
+<input
+  type="password"
+  class="attributes are not broken up by default which is the prettier behavior but {'breakable' + 'mustache tags'} can be broken up"
+   />
+
+<p>Text with spaces inbetween should break at the most fitting point and not wait for a {'breakable' + 'mustache tags'} to be broken up. {'If the mustache tag itself is very long, however' + 'it should be broken uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuup'}</p>

--- a/test/formatting/samples/long-mustache-value/output.html
+++ b/test/formatting/samples/long-mustache-value/output.html
@@ -1,0 +1,10 @@
+<input
+    type="password"
+    class="attributes are not broken up by default which is the prettier behavior but {'breakable' +
+        'mustache tags'} can be broken up" />
+
+<p>
+    Text with spaces inbetween should break at the most fitting point and not
+    wait for a {"breakable" + "mustache tags"} to be broken up. {"If the mustache tag itself is very long, however" +
+        "it should be broken uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuup"}
+</p>

--- a/test/formatting/samples/long-mustache-value/output.html
+++ b/test/formatting/samples/long-mustache-value/output.html
@@ -7,4 +7,5 @@
     Text with spaces inbetween should break at the most fitting point and not
     wait for a {"breakable" + "mustache tags"} to be broken up. {"If the mustache tag itself is very long, however" +
         "it should be broken uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuup"}
+    {andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaakaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
 </p>

--- a/test/printer/samples/long-control-blocks-dont-break.html
+++ b/test/printer/samples/long-control-blocks-dont-break.html
@@ -1,0 +1,17 @@
+{#if andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaak === true && cool}
+    a
+{:else if andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaak === true && cool}
+    b
+{/if}
+
+{#each [1, andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaak] as { cool, veryCool }}
+    a
+{/each}
+
+{#key andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaak.no.no.no}
+    a
+{/key}
+
+{#await Promise.resolve(andIiiiiiiiiiiiiiiiiiiiiiiiiiiWillNeverBreaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaak) then cool}
+    a
+{/await}


### PR DESCRIPTION
Possibly break all JS expressions except Svelte Blocks

Fixes #170

### BREAKING CHANGE
If the js content inside a mustache tag is too long, break it up if possible. Only exception are Svelte Blocks (#if/#await/etc) because that looks stupid.