### PR TITLE
Make it possible to have script/style without newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Everything that is not explicitely a block element is now treated as an inline element, including components. This is a breaking change ([#159](https://github.com/sveltejs/prettier-plugin-svelte/issues/159))
 * Single quotes are no longer forced except inside quoted attributes/events/etc. This is a breaking change ([#94](https://github.com/sveltejs/prettier-plugin-svelte/issues/94))
 * If the content inside a mustache tag is too long, break it up if possible. Only exception are Svelte Blocks (#if/#await/etc). This is a breaking change ([#170](https://github.com/sveltejs/prettier-plugin-svelte/issues/170))
+* If the content of a script/style tag is completely empty (no whitespace), don't add a hardline anymore. ([#87](https://github.com/sveltejs/prettier-plugin-svelte/issues/87))
 
 ## 1.4.2
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -184,6 +184,8 @@ function embedTag(
         isNodeSupportedLanguage(node) && !isIgnoreDirective(previousComment)
             ? content.trim() !== ''
                 ? formatBodyContent(content)
+                : content === ''
+                ? ''
                 : hardline
             : preformattedBody(content);
 

--- a/test/formatting/samples/scripts-styles-empty-handling/input.html
+++ b/test/formatting/samples/scripts-styles-empty-handling/input.html
@@ -1,0 +1,7 @@
+<script context="module"></script>
+
+<script> </script>
+
+<style>
+
+</style>

--- a/test/formatting/samples/scripts-styles-empty-handling/output.html
+++ b/test/formatting/samples/scripts-styles-empty-handling/output.html
@@ -1,0 +1,7 @@
+<script context="module"></script>
+
+<script>
+</script>
+
+<style>
+</style>


### PR DESCRIPTION
If the content of a script/style tag is completely empty (no whitespace), don't add a hardline anymore.
Fixes #87