### PR TITLE
(fix) svelteBracketNewLine true print > in separate line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prettier-plugin-svelte changelog
 
+## 2.0.4 (Unreleased)
+
+* When `svelteBracketNewLine` is set to `true` and only the closing tag is hugged, print the closing `>` in a separate line.
+
 ## 2.0.3
 
 * When `svelteBracketNewLine` is set to `false`, don't print the closing `>` in a separate line if possible ([#183](https://github.com/sveltejs/prettier-plugin-svelte/issues/183))

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -324,7 +324,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                             concat([noHugSeparatorStart, groupConcat([body(), `</${node.name}`])]),
                         ),
                     ),
-                    canOmitSoftlineBeforeClosingTag(node, path, options) ? '' : '',
+                    canOmitSoftlineBeforeClosingTag(node, path, options) ? '' : softline,
                     '>',
                 ]);
             }

--- a/test/formatting/samples/inline-element-with-children-ws/input.html
+++ b/test/formatting/samples/inline-element-with-children-ws/input.html
@@ -13,3 +13,5 @@
   <Tag />
 
 </b>
+
+<span class="asd asd asd asd asd asd asd asda sd asd asd"> <Component foo="bar" />Text</span>

--- a/test/formatting/samples/inline-element-with-children-ws/output.html
+++ b/test/formatting/samples/inline-element-with-children-ws/output.html
@@ -10,3 +10,7 @@
 
     <Tag />
 </b>
+
+<span class="asd asd asd asd asd asd asd asda sd asd asd">
+    <Component foo="bar" />Text</span
+>


### PR DESCRIPTION
When `svelteBracketNewLine` is set to `true` and only the closing tag is hugged, print the closing `>` in a separate line. Fixes a bug introduced in 2.0.3.