### PR TITLE
(fix) svelteBracketNewLine fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prettier-plugin-svelte changelog
 
+## 2.1.1 (Unreleased)
+
+* Fix `svelteBracketNewLine: true` sometimes not having `>` on a separate line ([#194](https://github.com/sveltejs/prettier-plugin-svelte/issues/194))
+
 ## 2.1.0
 
 * Support Prettier's `htmlWhitespaceSensitivity` setting

--- a/test/formatting/samples/attributes-newline/input.html
+++ b/test/formatting/samples/attributes-newline/input.html
@@ -1,0 +1,4 @@
+<button class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </button>
+<div class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </div>
+<span class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </span>
+<p class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </p>

--- a/test/formatting/samples/attributes-newline/output.html
+++ b/test/formatting/samples/attributes-newline/output.html
@@ -1,0 +1,20 @@
+<button
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"
+>
+    Copy
+</button>
+<div
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"
+>
+    Copy
+</div>
+<span
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"
+>
+    Copy
+</span>
+<p
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"
+>
+    Copy
+</p>

--- a/test/formatting/samples/attributes-no-newline/input.html
+++ b/test/formatting/samples/attributes-no-newline/input.html
@@ -1,0 +1,4 @@
+<button class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </button>
+<div class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </div>
+<span class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </span>
+<p class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r"> Copy </p>

--- a/test/formatting/samples/attributes-no-newline/options.json
+++ b/test/formatting/samples/attributes-no-newline/options.json
@@ -1,0 +1,3 @@
+{
+    "svelteBracketNewLine": false
+}

--- a/test/formatting/samples/attributes-no-newline/output.html
+++ b/test/formatting/samples/attributes-no-newline/output.html
@@ -1,0 +1,16 @@
+<button
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r">
+    Copy
+</button>
+<div
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r">
+    Copy
+</div>
+<span
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r">
+    Copy
+</span>
+<p
+    class="bg-green-500 text-gray-100 hover:bg-green-400 flex items-center px-4 py-2 border border-l-0 rounded-r">
+    Copy
+</p>

--- a/test/printer/samples/empty-elements-no-newline.html
+++ b/test/printer/samples/empty-elements-no-newline.html
@@ -4,7 +4,7 @@
 
 <span
     class="some classsome classsome classsome classsome classsome classsome classsome classsome classsome classsome classsome classsome class"
-    ></span>
+></span>
 
 <span
     class="some classsome classsome classsome classsome classsome classsome classsome classsome classsome classsome classsome classsome class">

--- a/test/printer/samples/hug-content-edge-cases.html
+++ b/test/printer/samples/hug-content-edge-cases.html
@@ -1,0 +1,7 @@
+<span class="some classsome classsome classsome classsome classsomeddddddd"
+    >hi
+</span>
+
+<span class="some classsome classsome classsome classsome classs">
+    hithere</span
+>


### PR DESCRIPTION
Fixes #194
- Don't group body so start and end both break at the same time if they must
- Fix "should hug start?" logic in opening tag attributes