### PR TITLE
(fix) no empty line at the end of markdown embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prettier-plugin-svelte changelog
 
+## 2.1.3 (Unreleased)
+
+* Don't print empty line at the end of the code if embedded inside markdown ([#202](https://github.com/sveltejs/prettier-plugin-svelte/issues/202))
+
 ## 2.1.2
 
 * Keep whitespace around `<script>`/`<style>` tags ([#197](https://github.com/sveltejs/prettier-plugin-svelte/issues/197))

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -4,7 +4,7 @@ import { extractAttributes } from '../lib/extractAttributes';
 import { getText } from '../lib/getText';
 import { hasSnippedContent, unsnipContent } from '../lib/snipTagContent';
 import { parseSortOrder, SortOrderPart } from '../options';
-import { isEmptyDoc, isLine, trim } from './doc-helpers';
+import { isEmptyDoc, isLine, trim, trimRight } from './doc-helpers';
 import { flatten, isASTNode, isPreTagContent } from './helpers';
 import {
     checkWhitespaceAtEndOfSvelteBlock,
@@ -672,6 +672,15 @@ function printTopLevelParts(
     // Need to reset these because they are global and could affect the next formatting run
     ignoreNext = false;
     svelteOptionsDoc = undefined;
+
+    // If this is invoked as an embed of markdown, remove the last hardline.
+    // The markdown parser tries this, too, but fails because it does not
+    // recurse into concats. Doing this will prevent an empty line
+    // at the end of the embedded code block.
+    if (options.parentParser === 'markdown') {
+        const lastDoc = docs[docs.length - 1];
+        trimRight([lastDoc], isLine);
+    }
 
     return groupConcat([join(hardline, docs)]);
 }

--- a/test/printer/samples/markdown.md
+++ b/test/printer/samples/markdown.md
@@ -17,5 +17,4 @@ by offloading the formatting of the fenced code block to prettier-plugin-svelte.
         color: green;
     }
 </style>
-
 ```


### PR DESCRIPTION
Prettier's markdown parser tries to strip the last hardline of the embedded docs, but fails to do so in our case because it does not recurse into concat parts -> we need to strip it ourselves.
Fixes #202