### PR TITLE
(fix) embed check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prettier-plugin-svelte changelog
 
+## 2.1.6 (Unreleased)
+
+* Fix wrong removal of comment ([#207](https://github.com/sveltejs/prettier-plugin-svelte/issues/207))
+
 ## 2.1.5
 
 * Fix retrieval of comment belonging to `<script>`/`<style>` block ([#205](https://github.com/sveltejs/prettier-plugin-svelte/issues/205))

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -128,6 +128,12 @@ export function getLeadingComment(path: FastPath): CommentNode | undefined {
 export function doesEmbedStartAfterNode(node: Node, path: FastPath, siblings = getSiblings(path)) {
     const position = node.end;
     const root = path.stack[0];
+    // If node is not at the top level of html, an embed cannot start after it,
+    // because embeds are only at the top level
+    if (!root.html || !root.html.children || !root.html.children.includes(node)) {
+        return false;
+    }
+
     const embeds = [root.css, root.html, root.instance, root.js, root.module] as Node[];
 
     const nextNode = siblings[siblings.indexOf(node) + 1];

--- a/test/printer/samples/comment-at-end.html
+++ b/test/printer/samples/comment-at-end.html
@@ -1,0 +1,6 @@
+<div>
+    <div />
+    <!-- testing 123 -->
+</div>
+
+<style></style>


### PR DESCRIPTION
When checking if an embed starts after a node, return early if that node is not at the top level of html, because embeds cannot start after it.
Fixes #207