### PR TITLE
(fix) adjust according to Prettier 2.3.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * (fix) adjust snip regex to not break commented-out script/style tags ([#212](https://github.com/sveltejs/prettier-plugin-svelte/issues/212))
 * (fix) Don't snip style tag that is inside script tag ([#219](https://github.com/sveltejs/prettier-plugin-svelte/issues/219), [#70](https://github.com/sveltejs/prettier-plugin-svelte/issues/70))
 * (fix) Better formatting of long attribute values with mustache tags inbetween ([#221](https://github.com/sveltejs/prettier-plugin-svelte/pull/221))
+* (fix) Format properly when using Prettier 2.3.0+ ([#222](https://github.com/sveltejs/prettier-plugin-svelte/pull/222))
 
 ## 2.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,9 +1962,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-            "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
             "dev": true
         },
         "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@types/node": "^10.12.18",
         "@types/prettier": "^2.1.6",
         "ava": "3.15.0",
-        "prettier": "^2.2.1",
+        "prettier": "^2.3.0",
         "rollup": "2.36.0",
         "@rollup/plugin-commonjs": "14.0.0",
         "@rollup/plugin-node-resolve": "11.0.1",


### PR DESCRIPTION
Prettier 2.3.0 changed the representation of concats from `{ type: 'concat', parts: [..] }` to `[..]` (flat array). Update the parts which introspect the docs accordingly in a backwards-compatible way.