### PR TITLE
(feat) Support range ignores in HTML top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # prettier-plugin-svelte changelog
 
-## 2.2.1 (Unreleased)
+## 2.3.0 (Unreleased)
 
 * (fix) adjust snip regex to not break commented-out script/style tags ([#212](https://github.com/sveltejs/prettier-plugin-svelte/issues/212))
 * (fix) Don't snip style tag that is inside script tag ([#219](https://github.com/sveltejs/prettier-plugin-svelte/issues/219), [#70](https://github.com/sveltejs/prettier-plugin-svelte/issues/70))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * (fix) Better formatting of long attribute values with mustache tags inbetween ([#221](https://github.com/sveltejs/prettier-plugin-svelte/pull/221))
 * (fix) Format properly when using Prettier 2.3.0+ ([#222](https://github.com/sveltejs/prettier-plugin-svelte/pull/222))
 * (fix) Keep parantheses in script tags for which JS is assumed ([#218](https://github.com/sveltejs/prettier-plugin-svelte/issues/218))
+* (feat) Support range ignores in HTML top level ([#225](https://github.com/sveltejs/prettier-plugin-svelte/issues/225))
 
 ## 2.2.0
 

--- a/test/formatting/samples/prettier-ignore-range-1/input.html
+++ b/test/formatting/samples/prettier-ignore-range-1/input.html
@@ -1,0 +1,23 @@
+<script>
+    const a = true;
+</script>
+
+<div>
+    
+    I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<div>I need to adhere sadly
+
+    
+</div>

--- a/test/formatting/samples/prettier-ignore-range-1/output.html
+++ b/test/formatting/samples/prettier-ignore-range-1/output.html
@@ -1,0 +1,18 @@
+<script>
+    const a = true;
+</script>
+
+<div>I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<div>I need to adhere sadly</div>

--- a/test/formatting/samples/prettier-ignore-range-2/input.html
+++ b/test/formatting/samples/prettier-ignore-range-2/input.html
@@ -1,0 +1,17 @@
+<div>
+    
+    I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+<script>
+    const a = true;
+</script>

--- a/test/formatting/samples/prettier-ignore-range-2/output.html
+++ b/test/formatting/samples/prettier-ignore-range-2/output.html
@@ -1,0 +1,16 @@
+<script>
+    const a = true;
+</script>
+
+<div>I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->

--- a/test/formatting/samples/prettier-ignore-range-wrong/input.html
+++ b/test/formatting/samples/prettier-ignore-range-wrong/input.html
@@ -1,0 +1,14 @@
+<div>
+<!-- prettier-ignore-start -->
+
+<div      > no format madness here </div>
+
+<p>
+    no
+    toplevel
+</p>
+
+<!-- prettier-ignore-end -->
+</div>
+
+<div>We all need to adhere sadly</div>

--- a/test/formatting/samples/prettier-ignore-range-wrong/output.html
+++ b/test/formatting/samples/prettier-ignore-range-wrong/output.html
@@ -1,0 +1,11 @@
+<div>
+    <!-- prettier-ignore-start -->
+
+    <div>no format madness here</div>
+
+    <p>no toplevel</p>
+
+    <!-- prettier-ignore-end -->
+</div>
+
+<div>We all need to adhere sadly</div>

--- a/test/formatting/samples/prettier-ignore-ranges-and-lines/input.html
+++ b/test/formatting/samples/prettier-ignore-ranges-and-lines/input.html
@@ -1,0 +1,40 @@
+<div>
+    
+    I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<div>I need to adhere sadly
+
+    
+</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore -->
+<p>
+    I'm
+    freeeee!
+</p>
+<div>I need to adhere sadly
+
+    
+</div>

--- a/test/formatting/samples/prettier-ignore-ranges-and-lines/output.html
+++ b/test/formatting/samples/prettier-ignore-ranges-and-lines/output.html
@@ -1,0 +1,32 @@
+<div>I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<div>I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore -->
+<p>
+    I'm
+    freeeee!
+</p>
+<div>I need to adhere sadly</div>

--- a/test/printer/samples/prettier-ignore-range.html
+++ b/test/printer/samples/prettier-ignore-range.html
@@ -1,0 +1,18 @@
+<script>
+    const a = true;
+</script>
+
+<div>I need to adhere sadly</div>
+
+<!-- prettier-ignore-start -->
+
+<div      > format madness here </div>
+
+<p>
+    I'm
+    freeeee!
+</p>
+
+<!-- prettier-ignore-end -->
+
+<div>I need to adhere sadly</div>


### PR DESCRIPTION
`<!-- prettier-ignore-start --> ... <!-- prettier-ignore-end -->` is now supported at HTML top level
Closes #225