### PR TITLE
(fix) better check for hardline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # prettier-plugin-svelte changelog
 
+## 2.3.1 (Unreleased)
+
+* (fix) More robust check for hardline to prevent trailing empty lines in style/script tags ([#222](https://github.com/sveltejs/prettier-plugin-svelte/issues/222))
+
 ## 2.3.0
 
 * (fix) Adjust snip regex to not break commented-out `<script>`/`<style>` tags ([#212](https://github.com/sveltejs/prettier-plugin-svelte/issues/212))
 * (fix) Don't snip `<style>` tags that are inside `<script>` tags ([#219](https://github.com/sveltejs/prettier-plugin-svelte/issues/219), [#70](https://github.com/sveltejs/prettier-plugin-svelte/issues/70))
 * (fix) Better formatting of long attribute values with mustache tags in between ([#221](https://github.com/sveltejs/prettier-plugin-svelte/pull/221))
-* (fix) Format properly when using Prettier 2.3.0+ ([#222](https://github.com/sveltejs/prettier-plugin-svelte/pull/222))
+* (fix) Format properly when using Prettier 2.3.0+ ([#222](https://github.com/sveltejs/prettier-plugin-svelte/issues/222))
 * (fix) Keep parentheses in `<script>` tags for which JS is assumed ([#218](https://github.com/sveltejs/prettier-plugin-svelte/issues/218))
 * (feat) Support range ignores at HTML top level ([#225](https://github.com/sveltejs/prettier-plugin-svelte/issues/225))
 

--- a/src/print/doc-helpers.ts
+++ b/src/print/doc-helpers.ts
@@ -1,9 +1,41 @@
 import { Doc, doc } from 'prettier';
 import { findLastIndex } from './helpers';
 
+/**
+ * Check if doc is a hardline.
+ * We can't just rely on a simple equality check because the doc could be created with another
+ * runtime version of prettier than what we import, making a reference check fail.
+ */
+export function isHardline(docToCheck: Doc): boolean {
+    return docToCheck === doc.builders.hardline || deepEqual(docToCheck, doc.builders.hardline);
+}
+
+/**
+ * Simple deep equal function which suits our needs. Only works properly on POJOs without cyclic deps.
+ */
+function deepEqual(x: any, y: any): boolean {
+    if (x === y) {
+        return true;
+    } else if (typeof x == 'object' && x != null && typeof y == 'object' && y != null) {
+        if (Object.keys(x).length != Object.keys(y).length) return false;
+
+        for (var prop in x) {
+            if (y.hasOwnProperty(prop)) {
+                if (!deepEqual(x[prop], y[prop])) return false;
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
 export function isLine(docToCheck: Doc): boolean {
     return (
-        docToCheck === doc.builders.hardline ||
+        isHardline(docToCheck) ||
         (typeof docToCheck === 'object' && docToCheck.type === 'line') ||
         (typeof docToCheck === 'object' &&
             docToCheck.type === 'concat' &&


### PR DESCRIPTION
The check for hardline was insufficient. It could happen that one version of Prettier did create the docs, and another version of Prettier was used for strict reference equality of the hardline builder. Therefore do a deep equality check if the reference check fails.
This occurs for example for users using pnpm where the user's Prettier is resolved, but not the user's `prettier-plugin-svelte`.
Fixes #222