### PR TITLE
Add standalone build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .history
 plugin.js
 plugin.js.map
+standalone

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ node_modules
 .history
 plugin.js
 plugin.js.map
-standalone
+standalone.js
+standalone.js.map
+esm

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,15 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@rollup/plugin-alias": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.4.tgz",
+            "integrity": "sha512-9YN5h0bWlYFV0zpXwwAWGPUWh/A+kkoCqwrMb43LnuGfhnQqOjsGR+5uh4LGpAZbBBj8qR1Hno6CZadZs7hyCQ==",
+            "dev": true,
+            "requires": {
+                "slash": "^3.0.0"
+            }
+        },
         "@rollup/plugin-commonjs": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
@@ -132,6 +141,17 @@
                 "resolve": "^1.11.0"
             }
         },
+        "@rollup/plugin-inject": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz",
+            "integrity": "sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^3.0.4",
+                "estree-walker": "^1.0.1",
+                "magic-string": "^0.25.5"
+            }
+        },
         "@rollup/plugin-node-resolve": {
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.1.tgz",
@@ -144,18 +164,6 @@
                 "deepmerge": "^4.2.2",
                 "is-module": "^1.0.0",
                 "resolve": "^1.19.0"
-            },
-            "dependencies": {
-                "resolve": {
-                    "version": "1.19.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-                    "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-                    "dev": true,
-                    "requires": {
-                        "is-core-module": "^2.1.0",
-                        "path-parse": "^1.0.6"
-                    }
-                }
             }
         },
         "@rollup/pluginutils": {
@@ -167,14 +175,6 @@
                 "@types/estree": "0.0.39",
                 "estree-walker": "^1.0.1",
                 "picomatch": "^2.2.2"
-            },
-            "dependencies": {
-                "estree-walker": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-                    "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-                    "dev": true
-                }
             }
         },
         "@sindresorhus/is": {
@@ -199,9 +199,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.14.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.15.tgz",
-            "integrity": "sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g==",
+            "version": "10.17.60",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -211,9 +211,9 @@
             "dev": true
         },
         "@types/prettier": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
-            "integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
             "dev": true
         },
         "@types/resolve": {
@@ -432,16 +432,6 @@
                     "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
                     "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
                     "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.5.19",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-                    "dev": true,
-                    "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
-                    }
                 }
             }
         },
@@ -454,8 +444,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "binary-extensions": {
             "version": "2.1.0",
@@ -472,6 +461,18 @@
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
+                    }
+                }
             }
         },
         "blueimp-md5": {
@@ -546,7 +547,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -1218,8 +1218,7 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "ignore": {
             "version": "5.1.8",
@@ -2084,11 +2083,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-            "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
             }
         },
@@ -2482,9 +2482,9 @@
             }
         },
         "tslib": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-            "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
             "dev": true
         },
         "type-fest": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "standalone/index.mjs.map"
     ],
     "scripts": {
-        "build": "rollup -c && rollup -c rollup.standalone.config.js",
+        "build": "rollup -c && rollup -c rollup.standalone.cjs.config.js && rollup -c rollup.standalone.esm.config.js",
         "test": "ava",
         "prepare": "npm run build",
         "prepublishOnly": "npm test"

--- a/package.json
+++ b/package.json
@@ -3,17 +3,25 @@
     "version": "2.3.1",
     "description": "Svelte plugin for prettier",
     "main": "plugin.js",
-    "browser": {
-        "./plugin.js": "./standalone/index.js",
-        "./plugin.mjs": "./standalone/index.mjs"
+    "module": "esm/plugin.mjs",
+    "exports": {
+        ".": {
+            "browser": {
+                "import": "./esm/standalone.mjs",
+                "default": "./standalone.js"
+            },
+            "default": "./plugin.js"
+        },
+        "./standalone": {
+            "import": "./esm/standalone.mjs",
+            "default": "./standalone.js"
+        }
     },
     "files": [
         "plugin.js",
         "plugin.js.map",
-        "standalone/index.js",
-        "standalone/index.js.map",
-        "standalone/index.mjs",
-        "standalone/index.mjs.map"
+        "esm/**/*.mjs",
+        "esm/**/*.mjs.map"
     ],
     "scripts": {
         "build": "rollup -c && rollup -c rollup.standalone.cjs.config.js && rollup -c rollup.standalone.esm.config.js",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,20 @@
     "version": "2.3.1",
     "description": "Svelte plugin for prettier",
     "main": "plugin.js",
+    "browser": {
+        "./plugin.js": "./standalone/index.js",
+        "./plugin.mjs": "./standalone/index.mjs"
+    },
     "files": [
         "plugin.js",
-        "plugin.js.map"
+        "plugin.js.map",
+        "standalone/index.js",
+        "standalone/index.js.map",
+        "standalone/index.mjs",
+        "standalone/index.mjs.map"
     ],
     "scripts": {
-        "build": "rollup -c",
+        "build": "rollup -c && rollup -c rollup.standalone.config.js",
         "test": "ava",
         "prepare": "npm run build",
         "prepublishOnly": "npm test"
@@ -28,6 +36,8 @@
     },
     "homepage": "https://github.com/sveltejs/prettier-plugin-svelte#readme",
     "devDependencies": {
+        "@rollup/plugin-alias": "^3.1.4",
+        "@rollup/plugin-inject": "^4.0.2",
         "@types/node": "^10.12.18",
         "@types/prettier": "^2.1.6",
         "ava": "3.15.0",
@@ -44,5 +54,8 @@
     "peerDependencies": {
         "prettier": "^1.16.4 || ^2.0.0",
         "svelte": "^3.2.0"
+    },
+    "dependencies": {
+        "buffer": "^5.7.1"
     }
 }

--- a/rollup.standalone.cjs.config.js
+++ b/rollup.standalone.cjs.config.js
@@ -5,12 +5,11 @@ import inject from '@rollup/plugin-inject';
 import alias from '@rollup/plugin-alias';
 import path from 'path';
 
-const srcDir = path.resolve(__dirname, 'src');
 export default {
     input: 'src/index.ts',
     plugins: [
         alias({
-            entries: [{ find: /^prettier$/gm, replacement: `${srcDir}/standalone-shim` }],
+            entries: [{ find: /^prettier$/gm, replacement: `prettier/standalone` }],
         }),
         resolve({
             preferBuiltins: false,
@@ -22,17 +21,10 @@ export default {
             Buffer: ['buffer', 'Buffer'],
         }),
     ],
-    external: ['prettier/esm/standalone', 'svelte'],
-    output: [
-        {
-            file: 'standalone/index.js',
-            format: 'cjs',
-            sourcemap: true,
-        },
-        {
-            file: 'standalone/index.mjs',
-            format: 'esm',
-            sourcemap: true,
-        },
-    ],
+    external: ['prettier/standalone', 'svelte'],
+    output: {
+        file: 'standalone/index.js',
+        format: 'cjs',
+        sourcemap: true,
+    },
 };

--- a/rollup.standalone.cjs.config.js
+++ b/rollup.standalone.cjs.config.js
@@ -3,7 +3,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript';
 import inject from '@rollup/plugin-inject';
 import alias from '@rollup/plugin-alias';
-import path from 'path';
 
 export default {
     input: 'src/index.ts',
@@ -23,7 +22,7 @@ export default {
     ],
     external: ['prettier/standalone', 'svelte'],
     output: {
-        file: 'standalone/index.js',
+        file: 'standalone.js',
         format: 'cjs',
         sourcemap: true,
     },

--- a/rollup.standalone.cjs.config.js
+++ b/rollup.standalone.cjs.config.js
@@ -20,7 +20,7 @@ export default {
             Buffer: ['buffer', 'Buffer'],
         }),
     ],
-    external: ['prettier/standalone', 'svelte'],
+    external: ['prettier/standalone', 'svelte/compiler'],
     output: {
         file: 'standalone.js',
         format: 'cjs',

--- a/rollup.standalone.config.js
+++ b/rollup.standalone.config.js
@@ -1,0 +1,38 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript';
+import inject from '@rollup/plugin-inject';
+import alias from '@rollup/plugin-alias';
+import path from 'path';
+
+const srcDir = path.resolve(__dirname, 'src');
+export default {
+    input: 'src/index.ts',
+    plugins: [
+        alias({
+            entries: [{ find: /^prettier$/gm, replacement: `${srcDir}/standalone-shim` }],
+        }),
+        resolve({
+            preferBuiltins: false,
+            browser: true,
+        }),
+        commonjs(),
+        typescript({}),
+        inject({
+            Buffer: ['buffer', 'Buffer'],
+        }),
+    ],
+    external: ['prettier/esm/standalone', 'svelte'],
+    output: [
+        {
+            file: 'standalone/index.js',
+            format: 'cjs',
+            sourcemap: true,
+        },
+        {
+            file: 'standalone/index.mjs',
+            format: 'esm',
+            sourcemap: true,
+        },
+    ],
+};

--- a/rollup.standalone.esm.config.js
+++ b/rollup.standalone.esm.config.js
@@ -1,0 +1,31 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript';
+import inject from '@rollup/plugin-inject';
+import alias from '@rollup/plugin-alias';
+import path from 'path';
+
+const srcDir = path.resolve(__dirname, 'src');
+export default {
+    input: 'src/index.ts',
+    plugins: [
+        alias({
+            entries: [{ find: /^prettier$/gm, replacement: `${srcDir}/standalone-shim` }],
+        }),
+        resolve({
+            preferBuiltins: false,
+            browser: true,
+        }),
+        commonjs(),
+        typescript({}),
+        inject({
+            Buffer: ['buffer', 'Buffer'],
+        }),
+    ],
+    external: ['prettier/esm/standalone', 'svelte'],
+    output: {
+        file: 'standalone/index.mjs',
+        format: 'esm',
+        sourcemap: true,
+    },
+};

--- a/rollup.standalone.esm.config.js
+++ b/rollup.standalone.esm.config.js
@@ -22,7 +22,7 @@ export default {
             Buffer: ['buffer', 'Buffer'],
         }),
     ],
-    external: ['prettier/esm/standalone', 'svelte'],
+    external: ['prettier/esm/standalone', 'svelte/compiler'],
     output: {
         file: 'esm/standalone.mjs',
         format: 'esm',

--- a/rollup.standalone.esm.config.js
+++ b/rollup.standalone.esm.config.js
@@ -24,7 +24,7 @@ export default {
     ],
     external: ['prettier/esm/standalone', 'svelte'],
     output: {
-        file: 'standalone/index.mjs',
+        file: 'esm/standalone.mjs',
         format: 'esm',
         sourcemap: true,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { print } from './print';
 import { ASTNode } from './print/nodes';
 import { embed } from './embed';
 import { snipScriptAndStyleTagContent } from './lib/snipTagContent';
+import { parse as parseSvelte } from 'svelte/compiler';
 
 function locStart(node: any) {
     return node.start;
@@ -25,7 +26,8 @@ export const parsers: Record<string, Parser> = {
     svelte: {
         parse: (text) => {
             try {
-                return <ASTNode>{ ...require(`svelte/compiler`).parse(text), __isRoot: true };
+                // @ts-ignore
+                return <ASTNode>{ ...parseSvelte(text), __isRoot: true };
             } catch (err) {
                 if (err.start != null && err.end != null) {
                     // Prettier expects error objects to have loc.start and loc.end fields.

--- a/src/standalone-shim.mjs
+++ b/src/standalone-shim.mjs
@@ -1,0 +1,2 @@
+import prettier from 'prettier/esm/standalone';
+export const doc = prettier.doc;


### PR DESCRIPTION
The standalone build allows the plugin to be used in the browser, prettier/standalone. Allows for features such as in-browser formatting and codemods. 

Have added an exports field to package.json to ensure the correct standalone/node/esm/cjs version of the package is used based on environment.

I've also changed the 'svelte' exclude to 'svelte/compiler' in the standalone rollup configs, as the compiler was getting bundled in and I have the feeling it isnt intended to be. If this is the case, you may want to adjust the standard rollup config too.