### PR TITLE
Add option for printing single quotes in markup attributes

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ export interface PluginOptions {
     svelteBracketNewLine: boolean;
     svelteAllowShorthand: boolean;
     svelteIndentScriptAndStyle: boolean;
+    svelteMarkupSingleQuote: boolean;
 }
 
 function makeChoice(choice: string) {
@@ -87,6 +88,13 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
         description:
             'Whether or not to indent the code inside <script> and <style> tags in Svelte files',
     },
+    svelteMarkupSingleQuote: {
+        since: '2.6.0',
+        category: 'Svelte',
+        type: 'boolean',
+        default: false,
+        description: 'Use single quotes for markup attributes',
+    }
 };
 
 export type SortOrder =

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -388,9 +388,12 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 }
 
                 const quotes = !isLoneMustacheTag(node.value) || options.svelteStrictMode;
+                const quoteCharacter = options.svelteMarkupSingleQuote ? '\'' : '"';
+                const quoteReplacementCharacter = options.svelteMarkupSingleQuote ? '"' : '\'';
+                // TODO: Replace quoteCharacter with quoteReplacementCharacter in attrNodeValue
                 const attrNodeValue = printAttributeNodeValue(path, print, quotes, node);
                 if (quotes) {
-                    return concat([line, node.name, '=', '"', attrNodeValue, '"']);
+                    return concat([line, node.name, '=', quoteCharacter, attrNodeValue, quoteCharacter]);
                 } else {
                     return concat([line, node.name, '=', attrNodeValue]);
                 }

--- a/test/printer/samples/markup-single-quote.html
+++ b/test/printer/samples/markup-single-quote.html
@@ -1,0 +1,3 @@
+<script lang='ts'></script>
+
+<div class='test' />

--- a/test/printer/samples/markup-single-quote.options.json
+++ b/test/printer/samples/markup-single-quote.options.json
@@ -1,0 +1,3 @@
+{
+    "svelteMarkupSingleQuote": true
+}


### PR DESCRIPTION
As discussed in issue #253, here's my work in progress of a new `svelteMarkupSingleQuote` option.  