### PR TITLE
(fix) ignore whitespace sensitivity with Svelte components (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prettier-plugin-svelte changelog
 
+## 2.6.1 (Unreleased)
+
+* (fix) respect whitespace "ignore" setting for components ([#281](https://github.com/sveltejs/prettier-plugin-svelte/issues/281)) 
+
 ## 2.6.0
 
 * (feat) Support `{@const}` tag ([#272](https://github.com/sveltejs/prettier-plugin-svelte/issues/272))

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -397,7 +397,10 @@ export function shouldHugStart(
     }
 
     const firstChild = children[0];
-    return !isTextNodeStartingWithWhitespace(firstChild);
+    return !(
+        isTextNodeStartingWithWhitespace(firstChild) ||
+        options.htmlWhitespaceSensitivity === 'ignore'
+    );
 }
 
 /**
@@ -427,7 +430,9 @@ export function shouldHugEnd(
     }
 
     const lastChild = children[children.length - 1];
-    return !isTextNodeEndingWithWhitespace(lastChild);
+    return !(
+        isTextNodeEndingWithWhitespace(lastChild) || options.htmlWhitespaceSensitivity === 'ignore'
+    );
 }
 
 /**

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -396,11 +396,12 @@ export function shouldHugStart(
         return true;
     }
 
+    if (options.htmlWhitespaceSensitivity === 'ignore') {
+        return false;
+    }
+
     const firstChild = children[0];
-    return !(
-        isTextNodeStartingWithWhitespace(firstChild) ||
-        options.htmlWhitespaceSensitivity === 'ignore'
-    );
+    return !isTextNodeStartingWithWhitespace(firstChild);
 }
 
 /**
@@ -429,10 +430,12 @@ export function shouldHugEnd(
         return true;
     }
 
+    if (options.htmlWhitespaceSensitivity === 'ignore') {
+        return false;
+    }
+
     const lastChild = children[children.length - 1];
-    return !(
-        isTextNodeEndingWithWhitespace(lastChild) || options.htmlWhitespaceSensitivity === 'ignore'
-    );
+    return !isTextNodeEndingWithWhitespace(lastChild);
 }
 
 /**

--- a/test/formatting/samples/component-ignore-whitespace/input.html
+++ b/test/formatting/samples/component-ignore-whitespace/input.html
@@ -1,0 +1,5 @@
+<p><ExternalLink href="https://www.buymeacoffee.com">buy</ExternalLink>!</p>
+
+<p><ExternalLink href="https://www.buymeacoffee.com">buy me a</ExternalLink>!</p>
+
+<p><ExternalLink href="https://www.buymeacoffee.com">buy me a coffee</ExternalLink>!</p>

--- a/test/formatting/samples/component-ignore-whitespace/options.json
+++ b/test/formatting/samples/component-ignore-whitespace/options.json
@@ -1,0 +1,3 @@
+{
+    "htmlWhitespaceSensitivity": "ignore"
+}

--- a/test/formatting/samples/component-ignore-whitespace/output.html
+++ b/test/formatting/samples/component-ignore-whitespace/output.html
@@ -1,0 +1,11 @@
+<p><ExternalLink href="https://www.buymeacoffee.com">buy</ExternalLink>!</p>
+
+<p>
+    <ExternalLink href="https://www.buymeacoffee.com">buy me a</ExternalLink>!
+</p>
+
+<p>
+    <ExternalLink href="https://www.buymeacoffee.com">
+        buy me a coffee
+    </ExternalLink>!
+</p>


### PR DESCRIPTION
This change fixes #281 and it seems like the right thing to do. I've also added an additional test for this issue to catch any regressions.

I haven't extensively walked through the code base to check if this might have some unintentional impact. However, all of the tests do appear to pass.