### PR TITLE
(chore) replace deprecated String.prototype.substr()

### DIFF
--- a/src/lib/snipTagContent.ts
+++ b/src/lib/snipTagContent.ts
@@ -16,7 +16,7 @@ export function snipScriptAndStyleTagContent(source: string): string {
         const indexes: [number, number][] = [];
         let match = null;
         while ((match = regex.exec(source)) != null) {
-            if (!source.slice(match.index, match.index + 10).startsWith('<!--')) {
+            if (source.slice(match.index, match.index + 4) !== '<!--') {
                 indexes.push([match.index, regex.lastIndex]);
             }
         }

--- a/src/lib/snipTagContent.ts
+++ b/src/lib/snipTagContent.ts
@@ -16,7 +16,7 @@ export function snipScriptAndStyleTagContent(source: string): string {
         const indexes: [number, number][] = [];
         let match = null;
         while ((match = regex.exec(source)) != null) {
-            if (!source.substr(match.index, 10).startsWith('<!--')) {
+            if (!source.slice(match.index, match.index + 10).startsWith('<!--')) {
                 indexes.push([match.index, regex.lastIndex]);
             }
         }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.