### PR TITLE
Add support for printing Literal nodes

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -393,7 +393,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
         case 'Identifier':
             return node.name;
         case 'Literal':
-            return ' ' + node.raw;
+            return '' + node.raw;
         case 'AttributeShorthand': {
             return (node.expression as any).name;
         }

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -392,6 +392,8 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
             ]);
         case 'Identifier':
             return node.name;
+        case 'Literal':
+            return ' ' + node.raw;
         case 'AttributeShorthand': {
             return (node.expression as any).name;
         }

--- a/src/print/nodes.ts
+++ b/src/print/nodes.ts
@@ -45,6 +45,12 @@ export interface IdentifierNode extends BaseNode {
     name: string;
 }
 
+export interface LiteralNode extends BaseNode {
+    type: 'Literal';
+    data: string;
+    raw: string;
+}
+
 export interface AttributeShorthandNode extends BaseNode {
     type: 'AttributeShorthand';
     name: string;
@@ -283,6 +289,7 @@ export type Node =
     | MustacheTagNode
     | AttributeNode
     | IdentifierNode
+    | LiteralNode
     | AttributeShorthandNode
     | IfBlockNode
     | ElseBlockNode


### PR DESCRIPTION
Fixes "Error: unknown node type: Literal" when using `prettier.__debug.formatAST` with an AST from svelte.parse.

Related: https://github.com/sveltejs/prettier-plugin-svelte/issues/211 