### PR TITLE
(feat) support svelteSingleAttributePerLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,15 +137,44 @@ Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte
 | ------- | ----------------------------------------- | ------------------------------------ |
 | `true`  | `--svelte-indent-script-and-style <bool>` | `svelteIndentScriptAndStyle: <bool>` |
 
+### Svelte Single Attribute Per Line
+
+Whether or not to enforce single attribute per line when there are multiple attributes.
+
+Example:
+
+```html
+<!-- before formatting -->
+<div class="foo" bar={true}>content</div>
+<span class="foo" bar={true}>content</span>
+
+<!-- after formatting, svelteSingleAttributePerLine true -->
+<div
+    class="foo"
+    bar={true}
+>
+    content
+</div>
+<span
+    class="foo"
+    bar={true}>content</span
+>
+```
+
+| Default | CLI Override                                | API Override                           |
+| ------- | ------------------------------------------- | -------------------------------------- |
+| `false` | `--svelte-single-line-per-attribute <bool>` | `svelteSingleAttributePerLine: <bool>` |
+
 ### `.prettierrc` example
 
 ```json
 {
-  "svelteSortOrder" : "options-styles-scripts-markup",
-  "svelteStrictMode": true,
-  "svelteBracketNewLine": false,
-  "svelteAllowShorthand": false,
-  "svelteIndentScriptAndStyle": false
+    "svelteSortOrder": "options-styles-scripts-markup",
+    "svelteStrictMode": true,
+    "svelteBracketNewLine": false,
+    "svelteAllowShorthand": false,
+    "svelteIndentScriptAndStyle": false,
+    "svelteSingleAttributePerLine": true
 }
 ```
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,6 +1,7 @@
 import { Doc, doc, FastPath, ParserOptions } from 'prettier';
 import { getText } from './lib/getText';
 import { snippedTagContentAttribute } from './lib/snipTagContent';
+import { isBracketSameLine } from './options';
 import { PrintFn } from './print';
 import { isLine, removeParentheses, trimRight } from './print/doc-helpers';
 import { groupConcat, printWithPrependedAttributeLine } from './print/helpers';
@@ -16,7 +17,7 @@ import {
 import { ElementNode, Node, ScriptNode, StyleNode } from './print/nodes';
 
 const {
-    builders: { concat, hardline, indent, literalline },
+    builders: { concat, hardline, softline, indent, dedent, literalline },
     utils: { removeLines },
 } = doc;
 
@@ -213,9 +214,10 @@ function embedTag(
         '<',
         tag,
         indent(
-            groupConcat(
-                path.map(printWithPrependedAttributeLine(node, options, print), 'attributes'),
-            ),
+            groupConcat([
+                ...path.map(printWithPrependedAttributeLine(node, options, print), 'attributes'),
+                isBracketSameLine(options) ? '' : dedent(softline),
+            ]),
         ),
         '>',
     ]);

--- a/src/lib/extractAttributes.ts
+++ b/src/lib/extractAttributes.ts
@@ -1,8 +1,8 @@
 import { AttributeNode, TextNode } from '../print/nodes';
 
 export function extractAttributes(html: string): AttributeNode[] {
-    const extractAttributesRegex = /<[a-z]+\s*(.*?)>/i;
-    const attributeRegex = /([^\s=]+)(?:=("|')(.*?)\2)?/gi;
+    const extractAttributesRegex = /<[a-z]+[\s\n]*([\s\S]*?)>/im;
+    const attributeRegex = /([^\s=]+)(?:=("|')([\s\S]*?)\2)?/gim;
 
     const [, attributesString] = html.match(extractAttributesRegex)!;
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ export interface PluginOptions {
     svelteBracketNewLine: boolean;
     svelteAllowShorthand: boolean;
     svelteIndentScriptAndStyle: boolean;
+    svelteSingleAttributePerLine: boolean;
 }
 
 function makeChoice(choice: string) {
@@ -86,6 +87,14 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
         default: true,
         description:
             'Whether or not to indent the code inside <script> and <style> tags in Svelte files',
+    },
+    svelteSingleAttributePerLine: {
+        since: '',
+        category: 'Svelte',
+        type: 'boolean',
+        default: false,
+        description:
+            'Whether or not to enforce single attribute per line when there are multiple attributes',
     },
 };
 

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -394,14 +394,15 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 '<',
                 node.name,
                 indent(
-                    groupConcat(
-                        path.map(
+                    groupConcat([
+                        ...path.map(
                             printWithPrependedAttributeLine(node, options, print),
                             'attributes',
                         ),
-                    ),
+                        bracketSameLine ? '' : dedent(line),
+                    ]),
                 ),
-                ' />',
+                ...[bracketSameLine ? ' ' : '', '/>'],
             ]);
         case 'Identifier':
             return node.name;
@@ -1008,6 +1009,7 @@ function prepareChildren(
 ): Node[] {
     let svelteOptionsComment: Doc | undefined;
     const childrenWithoutOptions = [];
+    const bracketSameLine = isBracketSameLine(options);
 
     for (let idx = 0; idx < children.length; idx++) {
         const currentChild = children[idx];
@@ -1064,16 +1066,17 @@ function prepareChildren(
                 '<',
                 node.name,
                 indent(
-                    groupConcat(
-                        path.map(
+                    groupConcat([
+                        ...path.map(
                             printWithPrependedAttributeLine(node, options, print),
                             'children',
                             idx,
                             'attributes',
                         ),
-                    ),
+                        bracketSameLine ? '' : dedent(line),
+                    ]),
                 ),
-                ' />',
+                ...[bracketSameLine ? ' ' : '', '/>'],
             ]),
             hardline,
         ]);

--- a/test/formatting/samples/single-attribute-per-line/input.html
+++ b/test/formatting/samples/single-attribute-per-line/input.html
@@ -17,7 +17,7 @@
 
 <span id="x" class="y">Copy</span>
 
-<div id="x" class:y={true} style:marginLeft="4px" data-my-prop on:click={onClick} />
+<div id="x" class:y={true} style:marginLeft="4px" on:click={onClick} />
 
 <svelte:body on:mouseenter={handleMouseenter} on:mouseleave={handleMouseleave} />
 

--- a/test/formatting/samples/single-attribute-per-line/input.html
+++ b/test/formatting/samples/single-attribute-per-line/input.html
@@ -1,0 +1,38 @@
+<svelte:options immutable={true} accessors={true} />
+
+<script type="typescript" context="module">
+  const hi = "";
+</script>
+
+<script
+  type="typescript"
+>
+  const hi = "";
+</script>
+
+<div id="x" class="y" animate:flip use:autofocus {...props}>Copy</div>
+
+<div
+  id="x">Copy</div>
+
+<span id="x" class="y">Copy</span>
+
+<div id="x" class:y={true} style:marginLeft="4px" data-my-prop on:click={onClick} />
+
+<svelte:body on:mouseenter={handleMouseenter} on:mouseleave={handleMouseleave} />
+
+<svelte:component this={component} foo={bar} />
+
+<svelte:component
+  this={component}
+/>
+
+<svelte:element this={tag} on:click={handler}>
+  Foo
+</svelte:element>
+
+<svelte:fragment slot="named" let:foo>
+  <p>hi</p>
+</svelte:fragment>
+
+<svelte:window on:event={handler} bind:prop={value} />

--- a/test/formatting/samples/single-attribute-per-line/options.json
+++ b/test/formatting/samples/single-attribute-per-line/options.json
@@ -1,0 +1,3 @@
+{
+    "svelteSingleAttributePerLine": true
+}

--- a/test/formatting/samples/single-attribute-per-line/output.html
+++ b/test/formatting/samples/single-attribute-per-line/output.html
@@ -1,0 +1,68 @@
+<svelte:options
+    immutable={true}
+    accessors={true} />
+
+<script
+    type="typescript"
+    context="module">
+    const hi = "";
+</script>
+
+<script type="typescript">
+    const hi = "";
+</script>
+
+<div
+    id="x"
+    class="y"
+    animate:flip
+    use:autofocus
+    {...props}
+>
+    Copy
+</div>
+
+<div id="x">Copy</div>
+
+<span
+    id="x"
+    class="y">Copy</span
+>
+
+<div
+    id="x"
+    class:y={true}
+    style:marginLeft="4px"
+    data-my-prop
+    on:click={onClick}
+/>
+
+<svelte:body
+    on:mouseenter={handleMouseenter}
+    on:mouseleave={handleMouseleave} />
+
+<svelte:component
+    this={component}
+    foo={bar}
+/>
+
+<svelte:component this={component} />
+
+<svelte:element
+    this={tag}
+    on:click={handler}
+>
+    Foo
+</svelte:element>
+
+<svelte:fragment
+    slot="named"
+    let:foo
+>
+    <p>hi</p>
+</svelte:fragment>
+
+<svelte:window
+    on:event={handler}
+    bind:prop={value}
+/>

--- a/test/printer/samples/single-attribute-per-line-bracket-no-new-line.html
+++ b/test/printer/samples/single-attribute-per-line-bracket-no-new-line.html
@@ -1,12 +1,10 @@
 <svelte:options
     immutable={true}
-    accessors={true}
-/>
+    accessors={true} />
 
 <script
     type="typescript"
-    context="module"
->
+    context="module">
     const hi = "";
 </script>
 
@@ -19,8 +17,7 @@
     class="y"
     animate:flip
     use:autofocus
-    {...props}
->
+    {...props}>
     Copy
 </div>
 
@@ -28,43 +25,34 @@
 
 <span
     id="x"
-    class="y">Copy</span
->
+    class="y">Copy</span>
 
 <div
     id="x"
     class:y={true}
     style:marginLeft="4px"
-    on:click={onClick}
-/>
+    on:click={onClick} />
 
 <svelte:body
     on:mouseenter={handleMouseenter}
-    on:mouseleave={handleMouseleave}
-/>
+    on:mouseleave={handleMouseleave} />
 
 <svelte:component
     this={component}
-    foo={bar}
-/>
+    foo={bar} />
 
 <svelte:component this={component} />
 
 <svelte:element
     this={tag}
-    on:click={handler}
->
+    on:click={handler}>
     Foo
 </svelte:element>
 
 <svelte:fragment
     slot="named"
-    let:foo
->
-    <p>hi</p>
-</svelte:fragment>
+    let:foo><p>hi</p></svelte:fragment>
 
 <svelte:window
     on:event={handler}
-    bind:prop={value}
-/>
+    bind:prop={value} />

--- a/test/printer/samples/single-attribute-per-line-bracket-no-new-line.options.json
+++ b/test/printer/samples/single-attribute-per-line-bracket-no-new-line.options.json
@@ -1,0 +1,4 @@
+{
+    "svelteSingleAttributePerLine": true,
+    "bracketSameLine": true
+}

--- a/test/printer/samples/single-attribute-per-line.html
+++ b/test/printer/samples/single-attribute-per-line.html
@@ -1,0 +1,66 @@
+<svelte:options
+    immutable={true}
+    accessors={true} />
+
+<script
+    type="typescript"
+    context="module">
+    const hi = "";
+</script>
+
+<script type="typescript">
+    const hi = "";
+</script>
+
+<div
+    id="x"
+    class="y"
+    animate:flip
+    use:autofocus
+    {...props}
+>
+    Copy
+</div>
+
+<div id="x">Copy</div>
+
+<span
+    id="x"
+    class="y">Copy</span
+>
+
+<div
+    id="x"
+    class:y={true}
+    style:marginLeft="4px"
+    data-my-prop
+    on:click={onClick}
+/>
+
+<svelte:body
+    on:mouseenter={handleMouseenter}
+    on:mouseleave={handleMouseleave} />
+
+<svelte:component
+    this={component}
+    foo={bar}
+/>
+
+<svelte:component this={component} />
+
+<svelte:element
+    this={tag}
+    on:click={handler}
+>
+    Foo
+</svelte:element>
+
+<svelte:fragment
+    slot="named"
+    let:foo><p>hi</p></svelte:fragment
+>
+
+<svelte:window
+    on:event={handler}
+    bind:prop={value}
+/>

--- a/test/printer/samples/single-attribute-per-line.html
+++ b/test/printer/samples/single-attribute-per-line.html
@@ -1,10 +1,12 @@
 <svelte:options
     immutable={true}
-    accessors={true} />
+    accessors={true}
+/>
 
 <script
     type="typescript"
-    context="module">
+    context="module"
+>
     const hi = "";
 </script>
 
@@ -33,13 +35,13 @@
     id="x"
     class:y={true}
     style:marginLeft="4px"
-    data-my-prop
     on:click={onClick}
 />
 
 <svelte:body
     on:mouseenter={handleMouseenter}
-    on:mouseleave={handleMouseleave} />
+    on:mouseleave={handleMouseleave}
+/>
 
 <svelte:component
     this={component}

--- a/test/printer/samples/single-attribute-per-line.options.json
+++ b/test/printer/samples/single-attribute-per-line.options.json
@@ -1,0 +1,3 @@
+{
+    "svelteSingleAttributePerLine": true
+}


### PR DESCRIPTION
This PR addresses https://github.com/sveltejs/prettier-plugin-svelte/issues/305 by adding a new option `svelteSingleAttributePerLine`, mirroring behaviour of `singleAttributePerLine` from prettier.