### PR TITLE
docs: update usage with tailwindcss plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,19 @@ Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte
 
 ## Usage with Tailwind Prettier Plugin
 
-There's a Tailwind Prettier Plugin to format classes in a certain way. This plugin bundles `prettier-plugin-svelte`, so if you want to use the Tailwind plugin, uninstall `prettier-plugin-svelte` and use the Tailwind plugin instead. If you are using VS Code, make sure to have the Prettier extension installed and switch the default formatter for Svelte files to it.
+There is a [Tailwind Prettier Plugin](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) to format classes in a certain way. This plugin must be loaded last, so if you want to use the Tailwind plugin, disable Prettier auto-loading and place `prettier-plugin-tailwindcss` in the end of the plugins array. If you are using VS Code, make sure to have the Prettier extension installed and switch the default formatter for Svelte files to it.
+
+```json5
+// .prettierrc
+{
+  // ..
+  "plugins": [
+    "prettier-plugin-svelte",
+    "prettier-plugin-tailwindcss" // MUST come last
+  ],
+  "pluginSearchDirs": false
+}
+```
 
 More info: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#compatibility-with-other-prettier-plugins
 


### PR DESCRIPTION
> We've taken a new approach with our Prettier plugin where we no longer bundle any third-party Prettier plugins (including the Svelte plugin — more on that below). And, through a safe list, we've explicitly added support for the above plugins which currently have known incompatibilities.

> For Svelte users, we no longer bundle the `prettier-plugin-svelte` plugin within our plugin, so you'll need install and enable it using the instructions above.

Reference https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/31#issuecomment-1312202554