### PR TITLE
Add `package.json` to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         ".": {
             "types": "./index.d.ts",
             "default": "./plugin.js"
-        }
+        },
+        "./package.json": "./package.json"
     },
     "scripts": {
         "build": "rollup -c",


### PR DESCRIPTION
[Encountered](https://github.com/sveltejs/language-tools/issues/2106) after updating to the latest Svelte VSCode extension.  

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /Users/techniq/Documents/Development/carevoyance/code/apps/web/node_modules/prettier-plugin-svelte/package.json
    at new NodeError (node:internal/errors:387:5)
    at throwExportsNotFound (node:internal/modules/esm/resolve:464:9)
    at packageExportsResolve (node:internal/modules/esm/resolve:748:3)
    at resolveExports (node:internal/modules/cjs/loader:500:36)
    at Module._findPath (node:internal/modules/cjs/loader:540:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:996:27)
    at Function.resolve (node:internal/modules/cjs/helpers:108:19)
    at getPackageInfo (/Users/techniq/.vscode/extensions/svelte.svelte-vscode-107.9.0/node_modules/svelte-language-server/dist/src/importPackage.js:30:37)
    at SveltePlugin.formatDocument (/Users/techniq/.vscode/extensions/svelte.svelte-vscode-107.9.0/node_modules/svelte-language-server/dist/src/plugins/svelte/SveltePlugin.js:77:48)
    at async PluginHost.tryExecutePlugin (/Users/techniq/.vscode/extensions/svelte.svelte-vscode-107.9.0/node_modules/svelte-language-server/dist/src/plugins/PluginHost.js:342:20) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
```

I have this monkey patched in my local `node_modules/prettier-plugin-svelte/package.json` and it fixes prettier svelte formatting within VSCode within my environment.