### PR TITLE
docs: remove nonexistent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,44 +134,6 @@ Example:
 | ------- | --------------------------------- | ------------------------------ |
 | `true`  | `--svelte-allow-shorthand <bool>` | `svelteAllowShorthand: <bool>` |
 
-### Svelte Self Closing Elements
-
-Whether or not empty elements (such as `div`s) should be self-closed or not.
-
-Example:
-
-<!-- prettier-ignore -->
-```html
-<!-- svelteSelfCloseElements: "always" -->
-<div />
-
-<!-- svelteSelfCloseElements: "never" -->
-<div></div>
-```
-
-| Default   | CLI Override                         | API Override                       |          |
-| --------- | ------------------------------------ | ---------------------------------- | -------- |
-| `"never"` | `--svelte-self-close-elements <str>` | `svelteSelfCloseElements: "always" | "never"` |
-
-### Svelte Self Closing Components
-
-Whether or not empty components should be self-closed or not.
-
-Example:
-
-<!-- prettier-ignore -->
-```html
-<!-- svelteSelfCloseComponents: "always" -->
-<Component />
-
-<!-- svelteSelfCloseComponents: "never" -->
-<Component></Component>
-```
-
-| Default    | CLI Override                           | API Override                         |          |
-| ---------- | -------------------------------------- | ------------------------------------ | -------- |
-| `"always"` | `--svelte-self-close-components <str>` | `svelteSelfCloseComponents: "always" | "never"` |
-
 ### Svelte Bracket New Line
 
 > Deprecated since 2.5.0. Use Prettier 2.4.0 and [bracketSameLine](https://prettier.io/docs/en/options.html#bracket-line) instead.


### PR DESCRIPTION
It appears that the options `svelteSelfCloseElements` and `svelteSelfCloseComponents` were planned to be introduced in PR #379, but they were intentionally excluded. Consequently, these options have been removed from the documentation.