### PR TITLE
Add browser build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .history
 plugin.js
 plugin.js.map
+browser.js
+browser.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "3.1.2",
             "license": "MIT",
             "devDependencies": {
+                "@rollup/plugin-alias": "^5.1.0",
                 "@rollup/plugin-commonjs": "14.0.0",
                 "@rollup/plugin-node-resolve": "11.0.1",
                 "@types/node": "^14.0.0",
@@ -232,6 +233,38 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@rollup/plugin-alias": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+            "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+            "dev": true,
+            "dependencies": {
+                "slash": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-alias/node_modules/slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
             "types": "./index.d.ts",
             "default": "./plugin.js"
         },
+        "./browser": "./browser.js",
         "./package.json": "./package.json"
     },
     "scripts": {
@@ -37,6 +38,7 @@
     },
     "homepage": "https://github.com/sveltejs/prettier-plugin-svelte#readme",
     "devDependencies": {
+        "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "14.0.0",
         "@rollup/plugin-node-resolve": "11.0.1",
         "@types/node": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "files": [
         "plugin.js",
         "plugin.js.map",
+        "browser.js",
+        "browser.js.map",
         "index.d.ts"
     ],
     "types": "./index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,43 @@
+import alias from '@rollup/plugin-alias';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript';
 
-export default {
-    input: 'src/index.ts',
-    plugins: [resolve(), commonjs(), typescript()],
-    external: ['prettier', 'svelte'],
-    output: {
-        file: 'plugin.js',
-        format: 'cjs',
-        sourcemap: true,
+export default [
+    // CommonJS build
+    {
+        input: 'src/index.ts',
+        plugins: [resolve(), commonjs(), typescript()],
+        external: ['prettier', 'svelte/compiler'],
+        output: {
+            file: 'plugin.js',
+            format: 'cjs',
+            sourcemap: true,
+        },
     },
-};
+    // Browser build
+    // Supported use case: importing the plugin from a bundler like Vite or Webpack
+    // Unsupported use case: importing the plugin directly in the browser
+    {
+        input: 'src/index.ts',
+        plugins: [
+            alias({
+                // Replace imports from 'prettier' with 'prettier/standalone'
+                entries: [
+                    // But don't touch 'prettier/plugins/babel'
+                    { find: 'prettier/plugins/babel', replacement: 'prettier/plugins/babel' },
+                    { find: 'prettier', replacement: 'prettier/standalone' },
+                ],
+            }),
+            resolve(),
+            commonjs(),
+            typescript(),
+        ],
+        external: ['prettier/standalone', 'prettier/plugins/babel', 'svelte/compiler'],
+        output: {
+            file: 'browser.js',
+            format: 'esm',
+            sourcemap: true,
+        },
+    },
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { hasPragma, print } from './print';
 import { ASTNode } from './print/nodes';
 import { embed, getVisitorKeys } from './embed';
 import { snipScriptAndStyleTagContent } from './lib/snipTagContent';
+import { parse } from 'svelte/compiler';
 
 const babelParser = prettierPluginBabel.parsers.babel;
 
@@ -29,7 +30,7 @@ export const parsers: Record<string, Parser> = {
         hasPragma,
         parse: (text) => {
             try {
-                return <ASTNode>{ ...require(`svelte/compiler`).parse(text), __isRoot: true };
+                return <ASTNode>{ ...parse(text), __isRoot: true };
             } catch (err: any) {
                 if (err.start != null && err.end != null) {
                     // Prettier expects error objects to have loc.start and loc.end fields.


### PR DESCRIPTION
Closes #69

 *  #69

Heavily inspired by the great work already done by @cfraz89 in https://github.com/sveltejs/prettier-plugin-svelte/pull/239, this PR is a slightly more surgical approach, introducing the bare minimum changes to get a browser build to work.

I have tested it locally using `npm link` and it does work!

One drawback of this implementation is that it still exposes the reference to the global `Buffer`. This makes the code changes to this project minimal, but shifts the burden to consumers to perform some nasty hackery to get it to work, namely this:

```js
import * as prettierPluginSvelte from 'prettier-plugin-svelte/browser';
import { Buffer } from 'buffer';
globalThis.Buffer = Buffer;
````

I propose to make the change that removes the `Buffer` dependency separately, treating that as a separate issue that would be an enhancement to the browser build.

 * #418