### PR TITLE
Fix prettier removing closing brackets.

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -98,9 +98,9 @@ export function embed(path: FastPath, _options: Options) {
             if (node === parent.expression) {
                 parent.expression.end =
                     options.originalText.indexOf(
-                        ')',
+                        '}',
                         parent.context?.end ?? parent.expression.end,
-                    ) + 1;
+                    );
                 parent.context = null;
                 printSvelteBlockJS('expression');
             }


### PR DESCRIPTION
Fix for https://github.com/sveltejs/prettier-plugin-svelte/issues/428

The original codes looks for a closing `)`; the new one looks for a closing `}`. Both methods are flawed.

The original code would fail a test like `{@render mySnippet($t('my.i18n.code')) }` (this is the example, where the error was found: to fix it the string COULD be passed instead and the method called inside the snippet… but this would break some features of the IDE: translation-string substitution and autocorrect).

The new code would fail a test like `{@render mySnippet({my: 'object'}) }`.

Are there any ways to use a "real" JS-parser to find the range of the argument-brackets instead of doing these indexOf-workarounds?