### PR TITLE
feat: semi-standalone browser build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .history
 plugin.js
 plugin.js.map
+browser.js
+browser.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 plugin.js
 plugin.js.map
 browser.js
-browser.js.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.2.0 (Unreleased)
 
 -   (feat) format JSON script tags
+-   (feat) introduce separate entry point using `prettier/standalone`
 -   (fix) don't duplicate comments of nested script/style tags
 -   (fix) handle updated `Snippet` block AST shape
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ Since we are using configuration overrides to handle svelte files, you might als
 }
 ```
 
+## Usage in the browser
+
+Usage in the browser is semi-supported. You can import the plugin from `prettier-plugin-svelte/browser` to get a version that depends on `prettier/standalone` and therefore doesn't use any node APIs. What isn't supported in a good way yet is using this without a build step - you still need a bundler like Vite to build everything together as one self-contained package in advance.
+
 ## Migration
 
 ```diff

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "3.1.2",
             "license": "MIT",
             "devDependencies": {
+                "@rollup/plugin-alias": "^5.1.0",
                 "@rollup/plugin-commonjs": "14.0.0",
                 "@rollup/plugin-node-resolve": "11.0.1",
                 "@types/node": "^14.0.0",
@@ -232,6 +233,38 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@rollup/plugin-alias": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+            "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+            "dev": true,
+            "dependencies": {
+                "slash": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-alias/node_modules/slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
             "types": "./index.d.ts",
             "default": "./plugin.js"
         },
+        "./browser": "./browser.js",
         "./package.json": "./package.json"
     },
     "scripts": {
@@ -37,6 +38,7 @@
     },
     "homepage": "https://github.com/sveltejs/prettier-plugin-svelte#readme",
     "devDependencies": {
+        "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "14.0.0",
         "@rollup/plugin-node-resolve": "11.0.1",
         "@types/node": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "files": [
         "plugin.js",
         "plugin.js.map",
+        "browser.js",
+        "browser.js.map",
         "index.d.ts"
     ],
     "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
         "plugin.js",
         "plugin.js.map",
         "browser.js",
-        "browser.js.map",
         "index.d.ts"
     ],
     "types": "./index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,8 @@ export default [
     },
     // Browser build
     // Supported use case: importing the plugin from a bundler like Vite or Webpack
-    // Unsupported use case: importing the plugin directly in the browser
+    // Semi-supported use case: importing the plugin directly in the browser through using import maps.
+    //                          (semi-supported because it requires a svelte/compiler.cjs import map and the .cjs ending has the wrong mime type on CDNs)
     {
         input: 'src/index.ts',
         plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,43 @@
+import alias from '@rollup/plugin-alias';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript';
 
-export default {
-    input: 'src/index.ts',
-    plugins: [resolve(), commonjs(), typescript()],
-    external: ['prettier', 'svelte'],
-    output: {
-        file: 'plugin.js',
-        format: 'cjs',
-        sourcemap: true,
+export default [
+    // CommonJS build
+    {
+        input: 'src/index.ts',
+        plugins: [resolve(), commonjs(), typescript()],
+        external: ['prettier', 'svelte/compiler'],
+        output: {
+            file: 'plugin.js',
+            format: 'cjs',
+            sourcemap: true,
+        },
     },
-};
+    // Browser build
+    // Supported use case: importing the plugin from a bundler like Vite or Webpack
+    // Unsupported use case: importing the plugin directly in the browser
+    {
+        input: 'src/index.ts',
+        plugins: [
+            alias({
+                // Replace imports from 'prettier' with 'prettier/standalone'
+                entries: [
+                    // But don't touch 'prettier/plugins/babel'
+                    { find: 'prettier/plugins/babel', replacement: 'prettier/plugins/babel' },
+                    { find: 'prettier', replacement: 'prettier/standalone' },
+                ],
+            }),
+            resolve(),
+            commonjs(),
+            typescript(),
+        ],
+        external: ['prettier/standalone', 'prettier/plugins/babel', 'svelte/compiler'],
+        output: {
+            file: 'browser.js',
+            format: 'esm',
+            sourcemap: true,
+        },
+    },
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,12 +22,7 @@ export default [
         input: 'src/index.ts',
         plugins: [
             alias({
-                // Replace imports from 'prettier' with 'prettier/standalone'
-                entries: [
-                    // But don't touch 'prettier/plugins/babel'
-                    { find: 'prettier/plugins/babel', replacement: 'prettier/plugins/babel' },
-                    { find: 'prettier', replacement: 'prettier/standalone' },
-                ],
+                entries: [{ find: 'prettier', replacement: 'prettier/standalone' }],
             }),
             resolve(),
             commonjs(),
@@ -37,7 +32,6 @@ export default [
         output: {
             file: 'browser.js',
             format: 'esm',
-            sourcemap: true,
         },
     },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { hasPragma, print } from './print';
 import { ASTNode } from './print/nodes';
 import { embed, getVisitorKeys } from './embed';
 import { snipScriptAndStyleTagContent } from './lib/snipTagContent';
+import { parse } from 'svelte/compiler';
 
 const babelParser = prettierPluginBabel.parsers.babel;
 
@@ -29,7 +30,7 @@ export const parsers: Record<string, Parser> = {
         hasPragma,
         parse: (text) => {
             try {
-                return <ASTNode>{ ...require(`svelte/compiler`).parse(text), __isRoot: true };
+                return <ASTNode>{ ...parse(text), __isRoot: true };
             } catch (err: any) {
                 if (err.start != null && err.end != null) {
                     // Prettier expects error objects to have loc.start and loc.end fields.


### PR DESCRIPTION
Adds a semi-standalone browser build under `prettier-plugin-svelte/browser`.

part of #69 (full fix would mean import maps work, which they don't because you need `svelte/compiler.cjs` which has the wrong mime type on package CDNs - this isn't fixable within this package, rather needs a different file type upstream)
closes #239
closes #257
closes #417