### PR TITLE
chore: replace FastPath with AstPath

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,4 +1,4 @@
-import { Doc, doc, FastPath, Options } from 'prettier';
+import { Doc, doc, AstPath, Options } from 'prettier';
 import { getText } from './lib/getText';
 import { snippedTagContentAttribute } from './lib/snipTagContent';
 import { isBracketSameLine, ParserOptions } from './options';
@@ -49,7 +49,7 @@ export function getVisitorKeys(node: any, nonTraversableKeys: Set<string>): stri
 // - deepest property is calling embed first
 // - if embed returns a function, it will be called after the traversal in a second pass, in the same order (deepest first)
 // For performance reasons we try to only return functions when we're sure we need to transform something.
-export function embed(path: FastPath, _options: Options) {
+export function embed(path: AstPath, _options: Options) {
     const node: Node = path.getNode();
     const options = _options as ParserOptions;
     if (!options.locStart || !options.locEnd || !options.originalText) {
@@ -343,7 +343,7 @@ async function formatBodyContent(
 async function embedTag(
     tag: 'script' | 'style' | 'template',
     text: string,
-    path: FastPath,
+    path: AstPath,
     formatBodyContent: (content: string) => Promise<Doc>,
     print: PrintFn,
     isTopLevel: boolean,

--- a/src/print/helpers.ts
+++ b/src/print/helpers.ts
@@ -1,4 +1,4 @@
-import { Doc, doc, FastPath } from 'prettier';
+import { Doc, doc, AstPath } from 'prettier';
 import { PrintFn } from '.';
 import { formattableAttributes } from '../lib/elements';
 import { snippedTagContentAttribute } from '../lib/snipTagContent';
@@ -29,7 +29,7 @@ export function isASTNode(n: any): n is ASTNode {
     return n && n.__isRoot;
 }
 
-export function isPreTagContent(path: FastPath): boolean {
+export function isPreTagContent(path: AstPath): boolean {
     const stack = path.stack as Node[];
 
     return stack.some(

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,4 +1,4 @@
-import { Doc, doc, FastPath } from 'prettier';
+import { Doc, doc, AstPath } from 'prettier';
 import { formattableAttributes, selfClosingTags } from '../lib/elements';
 import { hasSnippedContent, unsnipContent } from '../lib/snipTagContent';
 import { isBracketSameLine, ParserOptions, parseSortOrder, SortOrderPart } from '../options';
@@ -56,7 +56,7 @@ import {
 const { join, line, group, indent, dedent, softline, hardline, fill, breakParent, literalline } =
     doc.builders;
 
-export type PrintFn = (path: FastPath) => Doc;
+export type PrintFn = (path: AstPath) => Doc;
 
 declare module 'prettier' {
     export namespace doc {
@@ -76,7 +76,7 @@ let ignoreNext = false;
 let ignoreRange = false;
 let svelteOptionsDoc: Doc | undefined;
 
-export function print(path: FastPath, options: ParserOptions, print: PrintFn): Doc {
+export function print(path: AstPath, options: ParserOptions, print: PrintFn): Doc {
     const bracketSameLine = isBracketSameLine(options);
 
     const n = path.getValue();
@@ -498,7 +498,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 if (ifNode.else) {
                     def.push(
                         path.map(
-                            (ifPath: FastPath<any>) => ifPath.call(print, 'else'),
+                            (ifPath: AstPath<any>) => ifPath.call(print, 'else'),
                             'children',
                         )[0],
                     );
@@ -739,7 +739,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
 function printTopLevelParts(
     n: ASTNode,
     options: ParserOptions,
-    path: FastPath<any>,
+    path: AstPath<any>,
     print: PrintFn,
 ): Doc {
     if (options.svelteSortOrder === 'none') {
@@ -825,7 +825,7 @@ function printTopLevelParts(
 }
 
 function printAttributeNodeValue(
-    path: FastPath<any>,
+    path: AstPath<any>,
     print: PrintFn,
     quotes: boolean,
     node: AttributeNode | StyleDirectiveNode,
@@ -839,7 +839,7 @@ function printAttributeNodeValue(
     }
 }
 
-function printSvelteBlockChildren(path: FastPath, print: PrintFn, options: ParserOptions): Doc {
+function printSvelteBlockChildren(path: AstPath, print: PrintFn, options: ParserOptions): Doc {
     const node = path.getValue();
     const children = node.children;
     if (!children || children.length === 0) {
@@ -876,7 +876,7 @@ function printSvelteBlockChildren(path: FastPath, print: PrintFn, options: Parse
 function printPre(
     node: Parameters<typeof printRaw>[0],
     originalText: string,
-    path: FastPath,
+    path: AstPath,
     print: PrintFn,
 ): Doc {
     const result: Doc = [];
@@ -896,7 +896,7 @@ function printPre(
     return result;
 }
 
-function printChildren(path: FastPath, print: PrintFn, options: ParserOptions): Doc {
+function printChildren(path: AstPath, print: PrintFn, options: ParserOptions): Doc {
     if (isPreTagContent(path)) {
         return path.map(print, 'children');
     }
@@ -1050,7 +1050,7 @@ function printChildren(path: FastPath, print: PrintFn, options: ParserOptions): 
  */
 function prepareChildren(
     children: Node[],
-    path: FastPath,
+    path: AstPath,
     print: PrintFn,
     options: ParserOptions,
 ): Node[] {
@@ -1107,7 +1107,7 @@ function prepareChildren(
     function printSvelteOptions(
         node: OptionsNode,
         idx: number,
-        path: FastPath,
+        path: AstPath,
         print: PrintFn,
     ): void {
         svelteOptionsDoc = group([
@@ -1181,7 +1181,7 @@ function splitTextToDocs(node: TextNode): Doc[] {
     return docs;
 }
 
-function printJS(path: FastPath, print: PrintFn, name: string) {
+function printJS(path: AstPath, print: PrintFn, name: string) {
     return path.call(print, name);
 }
 

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -25,13 +25,13 @@ import {
     CommentInfo,
 } from './nodes';
 import { blockElements, TagName } from '../lib/elements';
-import { FastPath } from 'prettier';
+import { AstPath } from 'prettier';
 import { findLastIndex, isASTNode, isPreTagContent } from './helpers';
 import { ParserOptions, isBracketSameLine } from '../options';
 
 const unsupportedLanguages = ['coffee', 'coffeescript', 'styl', 'stylus', 'sass'];
 
-export function isInlineElement(path: FastPath, options: ParserOptions, node: Node) {
+export function isInlineElement(path: AstPath, options: ParserOptions, node: Node) {
     return (
         node && node.type === 'Element' && !isBlockElement(node, options) && !isPreTagContent(path)
     );
@@ -82,7 +82,7 @@ export function getChildren(node: Node): Node[] {
 /**
  * Returns siblings, that is, the children of the parent.
  */
-export function getSiblings(path: FastPath): Node[] {
+export function getSiblings(path: AstPath): Node[] {
     let parent: Node = path.getParentNode();
 
     if (isASTNode(parent)) {
@@ -95,7 +95,7 @@ export function getSiblings(path: FastPath): Node[] {
 /**
  * Returns the previous sibling node.
  */
-export function getPreviousNode(path: FastPath): Node | undefined {
+export function getPreviousNode(path: AstPath): Node | undefined {
     const node: Node = path.getNode();
     return getSiblings(path).find((child) => child.end === node.start);
 }
@@ -103,14 +103,14 @@ export function getPreviousNode(path: FastPath): Node | undefined {
 /**
  * Returns the next sibling node.
  */
-export function getNextNode(path: FastPath, node: Node = path.getNode()): Node | undefined {
+export function getNextNode(path: AstPath, node: Node = path.getNode()): Node | undefined {
     return getSiblings(path).find((child) => child.start === node.end);
 }
 
 /**
  * Returns the comment that is above the current node.
  */
-export function getLeadingComment(path: FastPath): CommentNode | undefined {
+export function getLeadingComment(path: AstPath): CommentNode | undefined {
     const siblings = getSiblings(path);
 
     let node: Node = path.getNode();
@@ -135,7 +135,7 @@ export function getLeadingComment(path: FastPath): CommentNode | undefined {
  * Did there use to be any embedded object (that has been snipped out of the AST to be moved)
  * at the specified position?
  */
-export function doesEmbedStartAfterNode(node: Node, path: FastPath, siblings = getSiblings(path)) {
+export function doesEmbedStartAfterNode(node: Node, path: AstPath, siblings = getSiblings(path)) {
     // If node is not at the top level of html, an embed cannot start after it,
     // because embeds are only at the top level
     if (!isNodeTopLevelHTML(node, path)) {
@@ -151,7 +151,7 @@ export function doesEmbedStartAfterNode(node: Node, path: FastPath, siblings = g
     return embeds.find((n) => n && n.start >= position && (!nextNode || n.end <= nextNode.start));
 }
 
-export function isNodeTopLevelHTML(node: Node, path: FastPath): boolean {
+export function isNodeTopLevelHTML(node: Node, path: AstPath): boolean {
     const root = path.stack[0];
     return !!root.html && !!root.html.children && root.html.children.includes(node);
 }
@@ -355,7 +355,7 @@ export function trimTextNodeLeft(node: TextNode): void {
  * Remove all leading whitespace up until the first non-empty text node,
  * and all trailing whitespace from the last non-empty text node onwards.
  */
-export function trimChildren(children: Node[], path: FastPath): void {
+export function trimChildren(children: Node[], path: AstPath): void {
     let firstNonEmptyNode = children.findIndex(
         (n) => !isEmptyTextNode(n) && !doesEmbedStartAfterNode(n, path),
     );
@@ -528,7 +528,7 @@ export function checkWhitespaceAtEndOfSvelteBlock(
     return 'none';
 }
 
-export function isInsideQuotedAttribute(path: FastPath, options: ParserOptions): boolean {
+export function isInsideQuotedAttribute(path: AstPath, options: ParserOptions): boolean {
     const stack = path.stack as Node[];
 
     return stack.some(
@@ -544,7 +544,7 @@ export function isInsideQuotedAttribute(path: FastPath, options: ParserOptions):
  */
 export function canOmitSoftlineBeforeClosingTag(
     node: Node,
-    path: FastPath,
+    path: AstPath,
     options: ParserOptions,
 ): boolean {
     return (
@@ -566,7 +566,7 @@ function hugsStartOfNextNode(node: Node, options: ParserOptions): boolean {
     return !options.originalText.substring(node.end).match(/^\s/);
 }
 
-function isLastChildWithinParentBlockElement(path: FastPath, options: ParserOptions): boolean {
+function isLastChildWithinParentBlockElement(path: AstPath, options: ParserOptions): boolean {
     const parent = path.getParentNode() as Node | undefined;
     if (!parent || !isBlockElement(parent, options)) {
         return false;


### PR DESCRIPTION
`FastPath` type has been deprecated in favor of `AstPath`.