### PR TITLE
chore: drop support for svelte 3 and 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Usage in the browser is semi-supported. You can import the plugin from `prettier
 
 ## Migration
 
+> For migrations between majors prior to `prettier-plugin-svelte@4` [see here](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3)
+
 Upgrade to Svelte 5 before upgrading to `prettier-plugin-svelte@4`, as it doesn't support older Svelte versions.
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This documentation is for prettier-plugin-svelte version 4 which only works with Svelte 5. See [this branch](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3) for documentation of earlier versions
+
 # Prettier for Svelte components
 
 Format your Svelte components using Prettier.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This documentation is for `prettier-plugin-svelte` version 4 which only works with Svelte 5. See [this branch](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3) for documentation of previous version.
+> This documentation is for `prettier-plugin-svelte` version 4 which only works with Svelte 5. See [this branch](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3) for documentation of previous versions.
 
 # Prettier for Svelte components
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Installing the plugin as a package allows:
 
 ### Compatibility
 
+-   `prettier-plugin-svelte@4` only works with `prettier@3`
 -   `prettier-plugin-svelte@3` only works with `prettier@3`
 -   `prettier-plugin-svelte@2` only works with `prettier@2`
 
@@ -56,8 +57,7 @@ If you want to customize some formatting behavior, see section [Options](#option
 Format your code using the Prettier CLI.
 
 ```bash
-npx prettier --write . # v3
-npx prettier --write --plugin prettier-plugin-svelte . # v2
+npx prettier --write .
 ```
 
 As part of your scripts in `package.json`:
@@ -67,8 +67,7 @@ As part of your scripts in `package.json`:
 {
     // ..
     "scripts": {
-        "format": "prettier --write .", // v3
-        "format": "prettier --write  --plugin prettier-plugin-svelte ." // v2
+        "format": "prettier --write ."
     }
 }
 ```
@@ -105,9 +104,7 @@ Example:
 
 <!-- prettier-ignore -->
 ```html
-<!-- svelteStrictMode: true (Svelte 3 and 4) -->
-<div foo="{bar}"></div>
-<!-- svelteStrictMode: true (Svelte 5) -->
+<!-- svelteStrictMode: true -->
 <div foo={bar}></div>
 
 <!-- svelteStrictMode: false -->
@@ -230,36 +227,7 @@ Usage in the browser is semi-supported. You can import the plugin from `prettier
 
 ## Migration
 
-```diff
-# package.json
-- "format": "prettier --plugin-search-dir . --write ."
-+ "format": "prettier --write ."
-```
-
-```diff
-# package.json
-- "prettier": "^2.8.8",
-+ "prettier": "^3.1.0",
-- "prettier-plugin-svelte": "^2.10.1",
-+ "prettier-plugin-svelte": "^3.1.0",
-```
-
-```diff
-# .prettierrc
-- "pluginSearchDirs": ["."],
-+ "plugins": ["prettier-plugin-svelte"]
-```
-
-Version 3 contains the following breaking changes:
-
--   Whether or not empty elements/components should self-close is now left to the user - in other words, if you write `<div />` or `<Component />` that stays as is, and so does `<div></div>`/`<Component></Component>`. If `svelteStrictMode` is turned on, it will still only allow `<div></div>` notation for elements (but it will leave your components alone)
--   `svelteAllowShorthand` now takes precedence over `svelteStrictMode`, which no longer has any effect on that behavior. Set `svelteAllowShorthand` to `false` to get back the v2 behavior
--   Some deprecated `svelteSortOrder` options were removed, see the the options section above for which values are valid for that options
-
-Version 3 of this plugin only works with Prettier version 3. Prettier version 3 contains some changes to how it loads plugins which may require you to adjust your configuration file:
-
--   Prettier no longer searches for plugins in the directory automatically, you need to tell Prettier specifically which plugins to use. This means you need to add `"plugins": ["prettier-plugin-svelte"]` to your config if you haven't already. Also remove the deprecated option `pluginSearchDirs`.
--   Prettier loads plugins from the plugin array differently. If you have used `require.resolve("prettier-plugin-svelte")` in your `.prettierrc.cjs` to tell Prettier where to find the plugin, you may need to remove that and just write `"prettier-plugin-svelte"` instead
+Upgrade to Svelte 5 before upgrading to `prettier-plugin-svelte@4`, as it doesn't support older Svelte versions.
 
 ## FAQ
 
@@ -283,15 +251,3 @@ becomes this
 ```
 
 it's because of whitespace sensitivity. For inline elements (`span`, `a`, etc) it makes a difference when rendered if there's a space (or newline) between them. Since we don't know if your slot inside your Svelte component is surrounded by inline elements, Svelte components are treated as such, too. You can adjust this whitespace sensitivity through [this setting](https://prettier.io/docs/en/options.html#html-whitespace-sensitivity). You can read more about HTML whitespace sensitivity [here](https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting).
-
-### Version 2 does not work in `pnpm`
-
-You may need to use a `.prettierrc.cjs` file instead to point Prettier to the exact location of the plugin using `require.resolve`:
-
-```js
-module.exports = {
-    pluginSearchDirs: false,
-    plugins: [require('prettier-plugin-svelte')],
-    overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }],
-};
-```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This documentation is for prettier-plugin-svelte version 4 which only works with Svelte 5. See [this branch](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3) for documentation of earlier versions
+> This documentation is for `prettier-plugin-svelte` version 4 which only works with Svelte 5. See [this branch](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3) for documentation of previous version.
 
 # Prettier for Svelte components
 
@@ -229,7 +229,7 @@ Usage in the browser is semi-supported. You can import the plugin from `prettier
 
 ## Migration
 
-> For migrations between majors prior to `prettier-plugin-svelte@4` [see here](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3)
+> For migration to `prettier-plugin-svelte@3` [see here](https://github.com/sveltejs/prettier-plugin-svelte/tree/version-3?tab=readme-ov-file#migration).
 
 Upgrade to Svelte 5 before upgrading to `prettier-plugin-svelte@4`, as it doesn't support older Svelte versions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,27 +17,39 @@
                 "prettier": "^3.0.0",
                 "rollup": "2.36.0",
                 "rollup-plugin-typescript": "1.0.1",
-                "svelte": "^4.2.7",
+                "svelte": "^5.0.0-next.243",
                 "ts-node": "^10.1.1",
                 "tslib": "^2.6.0",
                 "typescript": "5.1.3"
             },
             "peerDependencies": {
                 "prettier": "^3.0.0",
-                "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+                "svelte": "^5.0.0-next.243"
             }
         },
         "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -153,17 +165,29 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.4.tgz",
-            "integrity": "sha512-Oud2QPM5dHviZNn4y/WhhYKSXksv+1xLEIsNrAbGcFzUN3ubqWRFT5gwPchNc5NuzILOU4tPBDTZ4VwhL8Y7cw==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -176,19 +200,21 @@
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.9",
@@ -411,15 +437,26 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-typescript": {
+            "version": "1.4.13",
+            "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+            "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": ">=8.9.0"
             }
         },
         "node_modules/acorn-walk": {
@@ -696,12 +733,13 @@
             }
         },
         "node_modules/axobject-query": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
-            "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
             "dev": true,
-            "dependencies": {
-                "dequal": "^2.0.3"
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/balanced-match": {
@@ -1120,34 +1158,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/code-red": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-            "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15",
-                "@types/estree": "^1.0.1",
-                "acorn": "^8.10.0",
-                "estree-walker": "^3.0.3",
-                "periscopic": "^3.1.0"
-            }
-        },
-        "node_modules/code-red/node_modules/@types/estree": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-            "dev": true
-        },
-        "node_modules/code-red/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1251,19 +1261,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-            "dev": true,
-            "dependencies": {
-                "mdn-data": "2.0.30",
-                "source-map-js": "^1.0.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
             }
         },
         "node_modules/currently-unhandled": {
@@ -1500,6 +1497,13 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/esm-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+            "integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1512,6 +1516,24 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/esrap": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.2.2.tgz",
+            "integrity": "sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15",
+                "@types/estree": "^1.0.1"
+            }
+        },
+        "node_modules/esrap/node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/estree-walker": {
             "version": "1.0.1",
@@ -2323,12 +2345,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-            "dev": true
-        },
         "node_modules/mem": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
@@ -2688,41 +2704,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/periscopic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-            "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "estree-walker": "^3.0.0",
-                "is-reference": "^3.0.0"
-            }
-        },
-        "node_modules/periscopic/node_modules/@types/estree": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-            "dev": true
-        },
-        "node_modules/periscopic/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/periscopic/node_modules/is-reference": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-            "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "*"
             }
         },
         "node_modules/picomatch": {
@@ -3273,15 +3254,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/sourcemap-codec": {
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -3458,38 +3430,28 @@
             }
         },
         "node_modules/svelte": {
-            "version": "4.2.12",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.12.tgz",
-            "integrity": "sha512-d8+wsh5TfPwqVzbm4/HCXC783/KPHV60NvwitJnyTA5lWn1elhXMNWhXGCJ7PwPa8qFUnyJNIyuIRt2mT0WMug==",
+            "version": "5.0.0-next.243",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.243.tgz",
+            "integrity": "sha512-+oXjRInUyBfZXAEY8hmpf3F0eghAVCoWasotz1iOp2G5CyH4KR7jPxWOgjbgsgpL4zlMiN32MEYU1+I+QsC+nQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.15",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "@types/estree": "^1.0.1",
-                "acorn": "^8.9.0",
+                "@ampproject/remapping": "^2.3.0",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@types/estree": "^1.0.5",
+                "acorn": "^8.12.1",
+                "acorn-typescript": "^1.4.13",
                 "aria-query": "^5.3.0",
-                "axobject-query": "^4.0.0",
-                "code-red": "^1.0.3",
-                "css-tree": "^2.3.1",
-                "estree-walker": "^3.0.3",
-                "is-reference": "^3.0.1",
+                "axobject-query": "^4.1.0",
+                "esm-env": "^1.0.0",
+                "esrap": "^1.2.2",
+                "is-reference": "^3.0.2",
                 "locate-character": "^3.0.0",
-                "magic-string": "^0.30.4",
-                "periscopic": "^3.1.0"
+                "magic-string": "^0.30.11",
+                "zimmerframe": "^1.1.2"
             },
             "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/svelte/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.23",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
-            "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
+                "node": ">=18"
             }
         },
         "node_modules/svelte/node_modules/@types/estree": {
@@ -3497,15 +3459,6 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
             "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
             "dev": true
-        },
-        "node_modules/svelte/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
         },
         "node_modules/svelte/node_modules/is-reference": {
             "version": "3.0.2",
@@ -3517,15 +3470,13 @@
             }
         },
         "node_modules/svelte/node_modules/magic-string": {
-            "version": "0.30.7",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
-            "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+            "version": "0.30.11",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+            "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "node_modules/temp-dir": {
@@ -3881,6 +3832,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/zimmerframe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+            "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
         "prettier": "^3.0.0",
         "rollup": "2.36.0",
         "rollup-plugin-typescript": "1.0.1",
-        "svelte": "^4.2.7",
+        "svelte": "^5.0.0-next.243",
         "ts-node": "^10.1.1",
         "tslib": "^2.6.0",
         "typescript": "5.1.3"
     },
     "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+        "svelte": "^5.0.0-next.243"
     }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -52,12 +52,14 @@ export const options: Record<keyof PluginConfig, SupportOption> = {
             makeChoice('none'),
         ],
     },
+    // todo: remove in v4
     svelteStrictMode: {
         category: 'Svelte',
         type: 'boolean',
         default: false,
         description: 'More strict HTML syntax: Quotes in attributes, no self-closing DOM tags',
     },
+    // todo: remove in v4
     svelteBracketNewLine: {
         category: 'Svelte',
         type: 'boolean',

--- a/src/print/node-helpers.ts
+++ b/src/print/node-helpers.ts
@@ -270,6 +270,7 @@ export function isTypeScript(node: Node) {
 
 export function isJSON(node: Node) {
     const lang = getLangAttribute(node) || '';
+    // todo: check if this is still necessary
     // https://github.com/prettier/prettier/pull/6293
     return lang.endsWith('json') || lang.endsWith('importmap');
 }


### PR DESCRIPTION
Starting point for the next major version. I will follow up with PRs removing Svelte version checks and deprecated options once there are separate branches for `v3` and `next`.