### PR TITLE
fix: add missing exports types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Config } from 'prettier';
+import { Config, SupportOption, SupportLanguage, Parser, Printer } from 'prettier';
 
 export interface PluginConfig {
     svelteSortOrder?: SortOrder;
@@ -9,7 +9,7 @@ export interface PluginConfig {
 
 export type PrettierConfig = PluginConfig & Config;
 
-type SortOrder =
+export type SortOrder =
     | 'options-scripts-markup-styles'
     | 'options-scripts-styles-markup'
     | 'options-markup-styles-scripts'
@@ -35,3 +35,14 @@ type SortOrder =
     | 'styles-markup-scripts-options'
     | 'styles-scripts-markup-options'
     | 'none';
+
+export declare const options: Record<keyof PluginConfig, SupportOption>;
+export declare const languages: Partial<SupportLanguage>[];
+export declare const parsers: {
+    svelte: Parser;
+    svelteExpressionParser: Parser;
+    svelteTSExpressionParser: Parser;
+};
+export declare const printers: {
+    'svelte-ast': Printer;
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
             "types": "./index.d.ts",
             "default": "./plugin.js"
         },
-        "./browser": "./browser.js",
+        "./browser": {
+            "types": "./index.d.ts",
+            "default": "./browser.js"
+        },
         "./package.json": "./package.json"
     },
     "scripts": {


### PR DESCRIPTION
This PR adds:

1. missing types definations in `index.d.ts`
2. missing types field for `exports.browser` in `package.json`