### PR TITLE
chore: provide option to pass Svelte compiler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export interface PluginConfig {
     svelteBracketNewLine?: boolean;
     svelteAllowShorthand?: boolean;
     svelteIndentScriptAndStyle?: boolean;
+    svelte5CompilerPath?: string;
 }
 
 export type PrettierConfig = PluginConfig & Config;

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,6 +19,12 @@ function makeChoice(choice: string) {
 }
 
 export const options: Record<keyof PluginConfig, SupportOption> = {
+    svelte5CompilerPath: {
+        category: 'Svelte',
+        type: 'string',
+        default: '',
+        description: 'Only set this when using Svelte 5! Path to the Svelte 5 compiler',
+    },
     svelteSortOrder: {
         category: 'Svelte',
         type: 'choice',


### PR DESCRIPTION
Tooling can use this to work around some Svelte major version differences