### PR TITLE
typo fixed in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Example:
 
 | Default | CLI Override                      | API Override                   |
 | ------- | --------------------------------- | ------------------------------ |
-| `true`  | `--svelte-allow-shorthand <bool>` | `svelteAllowShorthand: <bool>` |
+| `false`  | `--svelte-allow-shorthand <bool>` | `svelteAllowShorthand: <bool>` |
 
 ### Svelte Bracket New Line
 


### PR DESCRIPTION
Svelte Allow Shorthand property's default value is false