### PR TITLE
feat: autoimport standalone from browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "exports": {
         ".": {
             "types": "./index.d.ts",
-            "default": "./plugin.js"
+            "default": "./plugin.js",
+            "browser": "./browser.js"
         },
         "./browser": "./browser.js",
         "./package.json": "./package.json"


### PR DESCRIPTION
> The [browser field](https://github.com/defunctzombie/package-browser-field-spec) in Prettier’s package.json points to standalone.js. That’s why you can just import or require the prettier module to access Prettier’s API, and your code can stay compatible with both Node and the browser as long as webpack or another bundler that supports the browser field is used. This is especially convenient for [plugins](https://prettier.io/docs/plugins).

from https://prettier.io/docs/browser

If the same structure is used for `prettier-plugin-svelte`, it will be a smoother experience for developers. I know this version is still unsupported, but loading the node version will be worse.
