### PR TITLE
docs: remove `overrides` configuration sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Then create a `.prettierrc` [configuration file](https://prettier.io/docs/en/con
 {
     // ..
     "plugins": ["prettier-plugin-svelte"],
-    "pluginSearchDirs": ["."], // should be removed in v3
-    "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+    "pluginSearchDirs": ["."] // should be removed in v3
 }
 ```
 


### PR DESCRIPTION
Prettier can automatically infers the parser from the input file path, so we don't need to set `overrides` in `.prettierrc`.

`overrides` is not used in test codes (https://github.com/search?q=repo%3Asveltejs%2Fprettier-plugin-svelte%20overrides&type=code)

How about removing it to prevent to misunderstand that `overrides` is required setting for `prettier-plugin-svelte`?
