### PR TITLE
fix: externalize all prettier imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prettier-plugin-svelte changelog
 
+## 3.4.1
+
+-   (fix) externalize all prettier imports
+
 ## 3.4.0
 
 -   (feat) Svelte 5: support attachments (`{@attach ...}`)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default [
     {
         input: 'src/index.ts',
         plugins: [resolve(), commonjs(), typescript()],
-        external: ['prettier', 'svelte/compiler'],
+        external: [/^(prettier|svelte)($|\/)/],
         output: {
             file: 'plugin.js',
             format: 'cjs',


### PR DESCRIPTION
The `prettier/plugins/babel` import wasn't ever externalized, which means whatever the prettier dependency resolved to at built time, that version of the prettier babel plugin was bundled. This is obviously wrong, but didn't cause problems until #506.

This properly externalizes all prettier (and svelte) imports, fixes #506