### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v6.0.6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 24
                   cache: pnpm
@@ -22,9 +22,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v6.0.6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 24
                   cache: pnpm
@@ -40,9 +40,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v6.0.6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 24
                   cache: pnpm
@@ -58,9 +58,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v6.0.6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 24
                   cache: pnpm
@@ -76,9 +76,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v6.0.6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 24
                   cache: pnpm

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - '@sveltejs/*'
+  - svelte
+  - esrap
+  - devalue
+  - zimmerframe
+  - prettier-plugin-svelte
+  - svelte-check
+  - esm-env
+blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,11 @@
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
-  - '@sveltejs/*'
-  - svelte
-  - esrap
-  - devalue
-  - zimmerframe
-  - prettier-plugin-svelte
-  - svelte-check
-  - esm-env
+    - '@sveltejs/*'
+    - svelte
+    - esrap
+    - devalue
+    - zimmerframe
+    - prettier-plugin-svelte
+    - svelte-check
+    - esm-env
 blockExoticSubdeps: true


### PR DESCRIPTION
Aligns this repo with the org-wide supply-chain hardening pass.

## Changes

- Add `pnpm-workspace.yaml` with:
  - `minimumReleaseAge: 2880` (2-day install delay for newly published versions)
  - `minimumReleaseAgeExclude: ['@sveltejs/*', svelte, esrap, devalue, zimmerframe, prettier-plugin-svelte, svelte-check, esm-env]`
  - `blockExoticSubdeps: true` (forbids transitive deps from resolving to git/tarball URLs)
- Pin all third-party GitHub Actions to full SHA with `# vX.Y.Z` comments in `ci.yml`:
  - `actions/checkout@v6`
  - `actions/setup-node@v6`
  - `pnpm/action-setup@v6.0.6`

## Notes

- `packageManager` already includes `+sha512` integrity (pnpm 10.33.4); no bump needed.
- Verified `pnpm install` runs cleanly.