### PR TITLE
fix: print `@const` correctly

### DIFF
--- a/.changeset/hungry-snakes-check.md
+++ b/.changeset/hungry-snakes-check.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-svelte': patch
+---
+
+fix: print `@const` correctly

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -124,10 +124,17 @@ export function embed(path: AstPath, _options: Options) {
         case 'AttachTag':
             printJS(parent, 'expression', {});
             break;
-        case 'ConstTag':
-            (parent as any).expression = (parent as AST.ConstTag).declaration.declarations[0];
-            printJS(parent, 'expression', { removeParentheses: true });
+        case 'VariableDeclarator': {
+            const declaration = path.getParentNode(1);
+            const constTag = path.getParentNode(2);
+
+            if (declaration?.type === 'VariableDeclaration' && constTag?.type === 'ConstTag') {
+                constTag.declaration = parent;
+                printJS(constTag, 'declaration', { removeParentheses: true });
+            }
+
             break;
+        }
         case 'BindDirective':
             printJS(parent, 'expression', {
                 removeParentheses: parent.expression.type === 'SequenceExpression',

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -701,7 +701,7 @@ export function print(path: AstPath, options: ParserOptions, print: PrintFn): Do
         case 'SpreadAttribute':
             return ['{...', printJS(path, print, 'expression'), '}'];
         case 'ConstTag':
-            return ['{@const ', printJS(path, print, 'expression'), '}'];
+            return ['{@const ', printJS(path, print, 'declaration'), '}'];
     }
 
     console.error(JSON.stringify(node, null, 4));

--- a/test/formatting/samples/const/input.html
+++ b/test/formatting/samples/const/input.html
@@ -7,3 +7,20 @@
 {#await aPromise then result}
     {@const bar = result ? 'some super long text which will force the ternary to break' : 'etc etc'}
 {/await}
+
+{#each items as item, index}
+    {@const result = someFunction(
+        item, index)}
+    {result}
+{/each}
+
+{#each items as item}
+    {@const display = type === 'abbrev' 
+        ? abbreviate(item) : item}
+    {display}
+{/each}
+
+{#each entries as entry}
+    {@const idx = list.findIndex((e) => e === entry)}
+    {idx}
+{/each}

--- a/test/formatting/samples/const/output.html
+++ b/test/formatting/samples/const/output.html
@@ -8,3 +8,18 @@
         ? "some super long text which will force the ternary to break"
         : "etc etc"}
 {/await}
+
+{#each items as item, index}
+    {@const result = someFunction(item, index)}
+    {result}
+{/each}
+
+{#each items as item}
+    {@const display = type === "abbrev" ? abbreviate(item) : item}
+    {display}
+{/each}
+
+{#each entries as entry}
+    {@const idx = list.findIndex((e) => e === entry)}
+    {idx}
+{/each}


### PR DESCRIPTION
Fixes #528

Prettier walks depth-first traversal with the deepest node called first. Since `ConstTag` is now nested a bit deeper we gotta switch our strategy of how we print it.