### PR TITLE
fix: preserve nested rest patterns in {#each} destructuring context

### DIFF
--- a/.changeset/nested-each-rest.md
+++ b/.changeset/nested-each-rest.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-svelte": patch
+---
+
+fix: preserve nested rest patterns in `{#each}` destructuring

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1454,7 +1454,8 @@ function _expandNode(node: any, original: string, parent?: any): string {
             }
         }
         case 'RestElement':
-            return ' ...' + node.argument.name;
+            // argument may be a nested Array/ObjectPattern, not only an Identifier
+            return ' ...' + _expandNode(node.argument, original).slice(1);
     }
 
     console.error(JSON.stringify(node, null, 4));

--- a/test/printer/samples/each-block-destructured-nested-rest.html
+++ b/test/printer/samples/each-block-destructured-nested-rest.html
@@ -1,0 +1,7 @@
+{#each array as [first, second, ...[third, ...{ length }]]}
+    <p>{first} {second} {third} {length}</p>
+{/each}
+
+{#each items as [head, ...{ length }]}
+    <p>{head} {length}</p>
+{/each}


### PR DESCRIPTION
`{#each items as [a, b, ...[c, d]]}` and `{#each items as [a, ...{ length }]}` were printed as `...undefined`, silently dropping the nested bindings.

`expandNode`'s `RestElement` case read `node.argument.name`, which is `undefined` when the rest argument is itself an `ArrayPattern` / `ObjectPattern` rather than a plain `Identifier`. Recurse into the argument instead so nested destructuring rest patterns round-trip.