### PR TITLE
fix: don't drop script/style content when the closing tag has whitespace

### DIFF
--- a/.changeset/nested-each-rest.md
+++ b/.changeset/nested-each-rest.md
@@ -1,5 +1,5 @@
 ---
-"prettier-plugin-svelte": patch
+'prettier-plugin-svelte': patch
 ---
 
 fix: preserve nested rest patterns in `{#each}` destructuring

--- a/.changeset/whitespace-closing-script-style.md
+++ b/.changeset/whitespace-closing-script-style.md
@@ -1,5 +1,5 @@
 ---
-"prettier-plugin-svelte": patch
+'prettier-plugin-svelte': patch
 ---
 
 fix: don't drop `<script>`/`<style>` content when the closing tag has whitespace (`</script >`)

--- a/.changeset/whitespace-closing-script-style.md
+++ b/.changeset/whitespace-closing-script-style.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-svelte": patch
+---
+
+fix: don't drop `<script>`/`<style>` content when the closing tag has whitespace (`</script >`)

--- a/src/lib/snipTagContent.ts
+++ b/src/lib/snipTagContent.ts
@@ -3,9 +3,9 @@ import { base64ToString, stringToBase64 } from '../base64-string';
 export const snippedTagContentAttribute = '✂prettier:content✂';
 
 const scriptRegex =
-    /<!--[^]*?-->|<script((?:\s+[^=>'"\/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"\/\s]+)*\s*)>([^]*?)<\/script>/g;
+    /<!--[^]*?-->|<script((?:\s+[^=>'"\/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"\/\s]+)*\s*)>([^]*?)<\/script\s*>/g;
 const styleRegex =
-    /<!--[^]*?-->|<style((?:\s+[^=>'"\/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"\/\s]+)*\s*)>([^]*?)<\/style>/g;
+    /<!--[^]*?-->|<style((?:\s+[^=>'"\/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"\/\s]+)*\s*)>([^]*?)<\/style\s*>/g;
 const langTsRegex = /\slang=["']?ts["']?/;
 
 export function snipScriptAndStyleTagContent(source: string): {

--- a/test/formatting/samples/whitespace-in-closing-script-style-tag/input.html
+++ b/test/formatting/samples/whitespace-in-closing-script-style-tag/input.html
@@ -1,0 +1,12 @@
+<script>
+    let name = "world";
+</script   >
+
+<h1>Hello {name}!</h1>
+
+<style>
+    h1 {
+        color: red;
+    }
+</style
+>

--- a/test/formatting/samples/whitespace-in-closing-script-style-tag/output.html
+++ b/test/formatting/samples/whitespace-in-closing-script-style-tag/output.html
@@ -1,0 +1,11 @@
+<script>
+    let name = "world";
+</script>
+
+<h1>Hello {name}!</h1>
+
+<style>
+    h1 {
+        color: red;
+    }
+</style>


### PR DESCRIPTION
The snip regexes that protect `<script>`/`<style>` bodies required the closing tag to be exactly `</script>` or `</style>`. As a result, valid tags such as `</script >` (with whitespace before `>`) were not matched, causing the body to be emitted as empty. Allow whitespace before `>` in closing tags.

The Svelte compiler accepts this syntax.

https://svelte.dev/playground/hello-world?version=5.56.3#H4sIAAAAAAAAE23LsQrCMBRG4VcJ_1KFoHusgpt7R-sQm1sIXG9Dc7VK6btLBMHB9fCdGeJvBIcTMQ9mGkYOZkUhKoU1LPrIlOHOM_SViisB9nsdU9rkB7GWdvWZ_vVuECXRDIc6d2NMag6ttMqkpnizN1XzwdWulXr7Y2QuYIGF0lPhdLzTcrFQH3mKEuB6z5mWN3T3Ct_HAAAA