### PR TITLE
fix: treat <textarea> content as whitespace-sensitive

### DIFF
--- a/.changeset/nested-each-rest.md
+++ b/.changeset/nested-each-rest.md
@@ -1,5 +1,5 @@
 ---
-"prettier-plugin-svelte": patch
+'prettier-plugin-svelte': patch
 ---
 
 fix: preserve nested rest patterns in `{#each}` destructuring

--- a/.changeset/textarea-whitespace.md
+++ b/.changeset/textarea-whitespace.md
@@ -1,5 +1,5 @@
 ---
-"prettier-plugin-svelte": patch
+'prettier-plugin-svelte': patch
 ---
 
 fix: preserve whitespace inside `<textarea>` (its content is whitespace-sensitive, like `<pre>`)

--- a/.changeset/textarea-whitespace.md
+++ b/.changeset/textarea-whitespace.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-svelte": patch
+---
+
+fix: preserve whitespace inside `<textarea>` (its content is whitespace-sensitive, like `<pre>`)

--- a/src/print/helpers.ts
+++ b/src/print/helpers.ts
@@ -26,7 +26,9 @@ export function isPreTagContent(path: AstPath): boolean {
 
     return stack.some(
         (node) =>
-            (node.type === 'RegularElement' && node.name.toLowerCase() === 'pre') ||
+            // pre and textarea preserve whitespace
+            (node.type === 'RegularElement' &&
+                ['pre', 'textarea'].includes(node.name.toLowerCase())) ||
             (node.type === 'Attribute' && !formattableAttributes.includes(node.name)),
     );
 }

--- a/test/printer/samples/textarea-preserve-whitespace.html
+++ b/test/printer/samples/textarea-preserve-whitespace.html
@@ -1,0 +1,9 @@
+<textarea>
+  A
+  B
+</textarea>
+
+<textarea name="value">
+  hello
+  world
+</textarea>


### PR DESCRIPTION
`<textarea>` content is whitespace-sensitive (it's the element's value), but the plugin reflowed/collapsed it. Include `textarea` alongside `pre` in `isPreTagContent` so the content is preserved verbatim, matching Prettier core.