### PR TITLE
fix: respect `singleQuote` in `<svelte:element this={'tag'}>` strings

### DIFF
--- a/.changeset/honest-spies-lead.md
+++ b/.changeset/honest-spies-lead.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-svelte': patch
+---
+
+fix: respect `singleQuote` in `<svelte:element this={'tag'}>` string literals

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -253,7 +253,7 @@ export function print(path: AstPath, options: ParserOptions, print: PrintFn): Do
                                     // Preserve <svelte:element this={"literal"}>
                                     // because in Svelte 6 this="literal" will be invalid
                                     if (expression_wrapped) {
-                                        return [open, `"${literal_value}"`, close];
+                                        return [open, printJS(path, print, 'tag'), close];
                                     }
                                     return [`"${literal_value}"`];
                                 }

--- a/test/formatting/samples/svelte-element-this-single-quote/input.html
+++ b/test/formatting/samples/svelte-element-this-single-quote/input.html
@@ -1,0 +1,1 @@
+<svelte:element this={"hello"}></svelte:element>

--- a/test/formatting/samples/svelte-element-this-single-quote/input.html
+++ b/test/formatting/samples/svelte-element-this-single-quote/input.html
@@ -1,1 +1,1 @@
-<svelte:element this={"hello"}></svelte:element>
+<svelte:element this={"foo"}></svelte:element>

--- a/test/formatting/samples/svelte-element-this-single-quote/options.json
+++ b/test/formatting/samples/svelte-element-this-single-quote/options.json
@@ -1,0 +1,3 @@
+{
+    "singleQuote": true
+}

--- a/test/formatting/samples/svelte-element-this-single-quote/output.html
+++ b/test/formatting/samples/svelte-element-this-single-quote/output.html
@@ -1,0 +1,1 @@
+<svelte:element this={'hello'}></svelte:element>

--- a/test/formatting/samples/svelte-element-this-single-quote/output.html
+++ b/test/formatting/samples/svelte-element-this-single-quote/output.html
@@ -1,1 +1,1 @@
-<svelte:element this={'hello'}></svelte:element>
+<svelte:element this={'foo'}></svelte:element>

--- a/test/printer/samples/svelte-element-single-quote.html
+++ b/test/printer/samples/svelte-element-single-quote.html
@@ -1,0 +1,1 @@
+<svelte:element this={'hello'}></svelte:element>

--- a/test/printer/samples/svelte-element-single-quote.html
+++ b/test/printer/samples/svelte-element-single-quote.html
@@ -1,1 +1,1 @@
-<svelte:element this={'hello'}></svelte:element>
+<svelte:element this={'foo'}></svelte:element>

--- a/test/printer/samples/svelte-element-single-quote.options.json
+++ b/test/printer/samples/svelte-element-single-quote.options.json
@@ -1,0 +1,3 @@
+{
+    "singleQuote": true
+}


### PR DESCRIPTION
The `svelte:element` `this` value hardcodes double quotes, not respecting the `singleQuote` option. Regression in v4 from 3.

(I used AI to find and fix this)