### PR TITLE
fix: make `menu` correctly a block

### DIFF
--- a/.changeset/happy-moments-pay.md
+++ b/.changeset/happy-moments-pay.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-svelte': patch
+---
+
+fix: make `menu` correctly a block

--- a/src/lib/elements.ts
+++ b/src/lib/elements.ts
@@ -46,6 +46,7 @@ export const blockElements: TagName[] = [
     'hr',
     'li',
     'main',
+    'menu',
     'nav',
     'ol',
     'p',

--- a/test/formatting/samples/block-element-menu/input.html
+++ b/test/formatting/samples/block-element-menu/input.html
@@ -1,0 +1,1 @@
+<menu>a</menu><menu>b</menu>

--- a/test/formatting/samples/block-element-menu/output.html
+++ b/test/formatting/samples/block-element-menu/output.html
@@ -1,0 +1,2 @@
+<menu>a</menu>
+<menu>b</menu>


### PR DESCRIPTION
`menu` is a block like `ul`, but is currently miscategorized causing formatting differences. The spec: https://html.spec.whatwg.org/multipage/rendering.html#lists

```css
dir, dd, dl, dt, menu, ol, ul { display: block; }
```